### PR TITLE
Automatically making X0 2d

### DIFF
--- a/pounders/py/checkinputss.py
+++ b/pounders/py/checkinputss.py
@@ -20,6 +20,7 @@ def checkinputss(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U):
         flag = -1
         return [flag, X0, mpmax, F0, L, U]
     # Verify X0 is the appropriate size
+    X0 = np.atleast_2d(X0)
     [nfs2, n2] = np.shape(X0)
     if n != n2:
         # Attempt to transpose:


### PR DESCRIPTION
Scipy.optimize and nlopt actually require a 1D starting point. It is nice to allow the same starting point to be passed to pounders.