### PR TITLE
Vectorized mult

### DIFF
--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -7,7 +7,6 @@ from bqmin import bqmin
 import sys
 
 
-@profile
 def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver, hfun=None, combinemodels=None):
     # POUNDERS: Practical Optimization Using No Derivatives for sums of Squares
     #   [X,F,flag,xkin] = ...


### PR DESCRIPTION
The previous loops over `m` can significantly slow down `pounders.py` (especially when `m` is large).

A simple test 

```
import numpy as np
import time

n = 10
m = 100000

A = np.random.uniform(-1, 1, (n, n, m))
x = np.random.uniform(-1, 1, n)
b = np.zeros(m)

st = time.time()
for j in range(m):
    b[j] = x @ A[:, :, j] @ x
print(time.time() - st)

st = time.time()
b2 = x @ np.tensordot(x, A, 1)
print(time.time() - st)

print(np.linalg.norm(b - b2))

```
on my laptop shows:
```
0.4768669605255127 # (previous approach)
0.009470462799072266 # (new approach)
7.533099139222156e-14 # (solution diff)
```
