### PR TITLE
Casting 1d bound arrays

### DIFF
--- a/pounders/py/checkinputss.py
+++ b/pounders/py/checkinputss.py
@@ -21,6 +21,8 @@ def checkinputss(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U):
         return [flag, X0, mpmax, F0, L, U]
     # Verify X0 is the appropriate size
     X0 = np.atleast_2d(X0)
+    L = np.atleast_2d(L)
+    U = np.atleast_2d(U)
     [nfs2, n2] = np.shape(X0)
     if n != n2:
         # Attempt to transpose:


### PR DESCRIPTION
A natural counterpart to #25 . Most python methods only allow 1D vectors.