### PR TITLE
Feature/pounders matlab coverage

### DIFF
--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -329,7 +329,7 @@ while nf < nfmax
                 flag = -2;
                 return
             else
-                rho = np.inf * sign(Fs(nf) - Fs(xkin));
+                rho = inf * sign(Fs(nf) - Fs(xkin));
             end
         end
 

--- a/pounders/m/tests/Testpounders.m
+++ b/pounders/m/tests/Testpounders.m
@@ -1,4 +1,4 @@
-classdef testPounders < matlab.unittest.TestCase
+classdef Testpounders < matlab.unittest.TestCase
     methods (Test)
 
         function realSolution(testCase)

--- a/pounders/m/tests/benchmark_pounders.m
+++ b/pounders/m/tests/benchmark_pounders.m
@@ -13,7 +13,7 @@ addpath([bendfo_location, '/data/']);
 addpath(minq_location);
 mkdir('benchmark_results');
 
-nfmax = 1000;
+nfmax = 100;
 gtol = 1e-13;
 factor = 10;
 
@@ -65,6 +65,7 @@ for row = 1:length(dfo)
             end
             hfun = @emittance_h;
             combinemodels = @emittance_combine;
+            printf = 2; % Just to test this feature
         end
         disp([row, hfun_cases]);
 

--- a/pounders/m/tests/make_coverage.m
+++ b/pounders/m/tests/make_coverage.m
@@ -1,12 +1,12 @@
-clear all
+clear all;
 suite = testsuite("test_pounders.m");
 import matlab.unittest.plugins.CodeCoveragePlugin
 import matlab.unittest.plugins.codecoverage.CoverageReport
 runner = testrunner("textoutput");
-% sourceCodeFolder = "../";
-sourceCodeFolder = "../../../../minq/m/";
+sourceCodeFolder = "../";
+% sourceCodeFolder = "../../../../minq/m/";
 reportFolder = "coverageReport";
 reportFormat = CoverageReport(reportFolder);
-p = CodeCoveragePlugin.forFolder(sourceCodeFolder,"Producing",reportFormat, "IncludingSubfolders", true);
-runner.addPlugin(p)
+p = CodeCoveragePlugin.forFolder(sourceCodeFolder, "Producing", reportFormat, "IncludingSubfolders", true);
+runner.addPlugin(p);
 results = runner.run(suite);

--- a/pounders/m/tests/make_coverage.m
+++ b/pounders/m/tests/make_coverage.m
@@ -1,0 +1,12 @@
+clear all
+suite = testsuite("test_pounders.m");
+import matlab.unittest.plugins.CodeCoveragePlugin
+import matlab.unittest.plugins.codecoverage.CoverageReport
+runner = testrunner("textoutput");
+% sourceCodeFolder = "../";
+sourceCodeFolder = "../../../../minq/m/";
+reportFolder = "coverageReport";
+reportFormat = CoverageReport(reportFolder);
+p = CodeCoveragePlugin.forFolder(sourceCodeFolder,"Producing",reportFormat, "IncludingSubfolders", true);
+runner.addPlugin(p)
+results = runner.run(suite);

--- a/pounders/m/tests/make_coverage.m
+++ b/pounders/m/tests/make_coverage.m
@@ -1,5 +1,5 @@
 clear all;
-suite = testsuite("test_pounders.m");
+suite = testsuite("Testpounders.m");
 import matlab.unittest.plugins.CodeCoveragePlugin
 import matlab.unittest.plugins.codecoverage.CoverageReport
 runner = testrunner("textoutput");

--- a/pounders/m/tests/testPounders.m
+++ b/pounders/m/tests/testPounders.m
@@ -1,13 +1,17 @@
-classdef test_pounders < matlab.unittest.TestCase
-    methods(Test)
+classdef testPounders < matlab.unittest.TestCase
+    methods (Test)
+
         function realSolution(testCase)
-            test_failing_objective
+            test_failing_objective;
         end
+
         function all(testCase)
-            benchmark_pounders
+            benchmark_pounders;
         end
+
         function more(testCase)
-            test_bounds_and_sp1
+            test_bounds_and_sp1;
         end
+
     end
 end

--- a/pounders/m/tests/testPounders.m
+++ b/pounders/m/tests/testPounders.m
@@ -1,0 +1,13 @@
+classdef test_pounders < matlab.unittest.TestCase
+    methods(Test)
+        function realSolution(testCase)
+            test_failing_objective
+        end
+        function all(testCase)
+            benchmark_pounders
+        end
+        function more(testCase)
+            test_bounds_and_sp1
+        end
+    end
+end

--- a/pounders/m/tests/test_bounds_and_sp1.m
+++ b/pounders/m/tests/test_bounds_and_sp1.m
@@ -6,7 +6,6 @@
 
 function [] = test_bounds_and_sp1()
 
-
 addpath('../');
 addpath('../general_h_funs');
 bendfo_location = '../../../../BenDFO';
@@ -14,7 +13,6 @@ addpath([bendfo_location, '/m/']);
 addpath([bendfo_location, '/data/']);
 minq_location = '../../../../minq/m/minq8/';
 addpath(minq_location);
-
 
 nfmax = 100;
 gtol = 1e-13;
@@ -42,8 +40,8 @@ for row = [7, 8]
 
     npmax = 2 * n + 1;  % Maximum number of interpolation points [2*n+1]
     if row == 7
-        L = -2*ones(1, n);
-        U = 2*ones(1, n);
+        L = -2 * ones(1, n);
+        U = 2 * ones(1, n);
     else
         L = [-12, 0];
         U = [0, 10];

--- a/pounders/m/tests/test_bounds_and_sp1.m
+++ b/pounders/m/tests/test_bounds_and_sp1.m
@@ -67,7 +67,7 @@ for row = [7, 8]
                 hfun = @(F)sum((F - 1 / length(F) * sum(F)).^2) - alpha * (1 / length(F) * sum(F))^2;
                 combinemodels = @squared_diff_from_mean;
             elseif hfun_cases == 3
-                hfun = @(F)-1*sum(F.^2);
+                hfun = @(F)-1 * sum(F.^2);
                 combinemodels = @neg_leastsquares;
             end
 

--- a/pounders/m/tests/test_bounds_and_sp1.m
+++ b/pounders/m/tests/test_bounds_and_sp1.m
@@ -66,6 +66,9 @@ for row = [7, 8]
                 alpha = 0; % If changed here, also needs to be adjusted in squared_diff_from_mean.m
                 hfun = @(F)sum((F - 1 / length(F) * sum(F)).^2) - alpha * (1 / length(F) * sum(F))^2;
                 combinemodels = @squared_diff_from_mean;
+            elseif hfun_cases == 3
+                hfun = @(F)-1*sum(F.^2);
+                combinemodels = @neg_leastsquares;
             end
 
             [X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver, hfun, combinemodels);

--- a/pounders/m/tests/test_bounds_and_sp1.m
+++ b/pounders/m/tests/test_bounds_and_sp1.m
@@ -1,0 +1,81 @@
+% This tests pounders
+%   - the spsolver=1 and spsolver=3 cases
+%   - the handling of bounds
+%   - printing
+%   - Using starting points in X0 and F0
+
+function [] = test_bounds_and_sp1()
+
+
+addpath('../');
+addpath('../general_h_funs');
+bendfo_location = '../../../../BenDFO';
+addpath([bendfo_location, '/m/']);
+addpath([bendfo_location, '/data/']);
+minq_location = '../../../../minq/m/minq8/';
+addpath(minq_location);
+
+
+nfmax = 100;
+gtol = 1e-13;
+factor = 10;
+
+load dfo.dat;
+
+for row = [7, 8]
+    nprob = dfo(row, 1);
+    n = dfo(row, 2);
+    m = dfo(row, 3);
+    factor_power = dfo(row, 4);
+
+    BenDFO.nprob = nprob;
+    BenDFO.m = m;
+    BenDFO.n = n;
+
+    xs = dfoxs(n, nprob, factor^factor_power);
+
+    SolverNumber = 0;
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % POUNDERs
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    npmax = 2 * n + 1;  % Maximum number of interpolation points [2*n+1]
+    if row == 7
+        L = -2*ones(1, n);
+        U = 2*ones(1, n);
+    else
+        L = [-12, 0];
+        U = [0, 10];
+    end
+
+    nfs = 1;
+    X0 = xs';
+    xkin = 1;
+    delta = 0.1;
+    printf = 1;
+    spsolver = 1;
+
+    objective = @(x)calfun_wrapper(x, BenDFO, 'smooth');
+    F0 = objective(X0)';
+
+    for spsolver = [1, 3]
+        for hfun_cases = 1:3
+            if hfun_cases == 1
+                hfun = @(F)sum(F.^2);
+                combinemodels = @leastsquares;
+            elseif hfun_cases == 2
+                alpha = 0; % If changed here, also needs to be adjusted in squared_diff_from_mean.m
+                hfun = @(F)sum((F - 1 / length(F) * sum(F)).^2) - alpha * (1 / length(F) * sum(F))^2;
+                combinemodels = @squared_diff_from_mean;
+            end
+
+            [X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver, hfun, combinemodels);
+        end
+    end
+end
+end
+
+function [fvec] = calfun_wrapper(x, struct, probtype)
+[~, fvec, ~] = calfun(x, struct, probtype);
+end

--- a/pounders/m/tests/test_failing_objective.m
+++ b/pounders/m/tests/test_failing_objective.m
@@ -29,3 +29,7 @@ objective = @(x)failing_objective(x);
 
 [X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver);
 assert(flag == -3, "No NaN was encountered in this test, but (with high probability) should have been.");
+
+% Intentionally not passing a function for an objective
+[X, F, flag, xk_best] = pounders(X0, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver);
+assert(flag == -1, "Should have failed");


### PR DESCRIPTION
Running `pounders/m/tests/make_coverage.m` builds html coverage reports for the `pounders/m` directory and subdirectories.

One line in `pounders/m/tests/make_coverage.m` can also be adjusted to get coverage for the subdirectories in `m/` in the poptus/minq repository. 