### PR TITLE
Trying to test all of bmpts.m

### DIFF
--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -59,6 +59,7 @@
 %               = -2 model failure
 %               = -3 error if a NaN was encountered
 %               = -4 error in TRSP Solver
+%               = -5 unable to get modelimprovement with current parameters
 % xkin    [int] Index of point in X representing approximate minimizer
 %
 % --DEPENDS ON-------------------------------------------------------------
@@ -180,6 +181,10 @@ while nf < nfmax
         end
         [~, np, valid, Gres, Hresdel, Mind] = ...
             formquad(X(1:nf, :), Res(1:nf, :), delta, xkin, npmax, Par, 0);
+        if np < n
+            [X, F, flag] = prepare_outputs_before_return(X, F, nf, -5);
+            return
+        end
     end
 
     % 1b. Update the quadratic model

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -59,7 +59,7 @@
 %               = -2 model failure
 %               = -3 error if a NaN was encountered
 %               = -4 error in TRSP Solver
-%               = -5 unable to get modelimprovement with current parameters
+%               = -5 unable to get model improvement with current parameters
 % xkin    [int] Index of point in X representing approximate minimizer
 %
 % --DEPENDS ON-------------------------------------------------------------

--- a/pounders/m/prepare_outputs_before_return.m
+++ b/pounders/m/prepare_outputs_before_return.m
@@ -12,6 +12,8 @@ function [X, F, exit_flag] = prepare_outputs_before_return(X, F, nf, exit_flag)
         disp("A NaN was encountered in an objective evaluation. Exiting.");
     elseif exit_flag == -2
         disp('Terminating because mdec == 0 with a valid model and no improvement from TRSP solution');
+    elseif exit_flag == -5
+        disp('Unable to improve model with current Pars; try dividing Par(3:4) by 10');
     elseif exit_flag == 0
         disp('g is sufficiently small');
     end

--- a/pounders/m/tests/Testpounders.m
+++ b/pounders/m/tests/Testpounders.m
@@ -1,16 +1,14 @@
 classdef Testpounders < matlab.unittest.TestCase
     methods (Test)
 
-        function realSolution(testCase)
+        function shortTests(testCase)
             test_failing_objective;
-        end
-
-        function all(testCase)
-            benchmark_pounders;
-        end
-
-        function more(testCase)
             test_bounds_and_sp1;
+            test_bmpts;
+        end
+
+        function longTest(testCase)
+            benchmark_pounders;
         end
 
     end

--- a/pounders/m/tests/test_bmpts.m
+++ b/pounders/m/tests/test_bmpts.m
@@ -18,8 +18,8 @@ U = ones(1, n); % Upper bounds
 X0 = zeros(3, n); % Starting points
 
 X0(1, :) = xs; % Near origin
-X0(2, :) = 10*xs; % Farther from origin
-X0(3, :) = 100*xs; % Colinear
+X0(2, :) = 10 * xs; % Farther from origin
+X0(3, :) = 100 * xs; % Colinear
 
 objective = @(x) x; % Identity mapping
 for i = 1:3

--- a/pounders/m/tests/test_bmpts.m
+++ b/pounders/m/tests/test_bmpts.m
@@ -9,11 +9,11 @@ gtol = 1e-13;
 n = 2;
 m = n;
 
-xs = 1e-8 * ones(1, n);
+xs = [1e-8 -1e-8];
 
 npmax = 2 * n + 1;  % Maximum number of interpolation points [2*n+1]
-L = zeros(1, n); % Lower bounds
-U = ones(1, n); % Upper bounds
+L = [0 -1]; % Lower bounds
+U = [1 0]; % Upper bounds
 
 X0 = zeros(3, n); % Starting points
 

--- a/pounders/m/tests/test_bmpts.m
+++ b/pounders/m/tests/test_bmpts.m
@@ -9,22 +9,21 @@ gtol = 1e-13;
 n = 2;
 m = n;
 
-xs = 1e-8*ones(1,n);
+xs = 1e-8 * ones(1, n);
 
 npmax = 2 * n + 1;  % Maximum number of interpolation points [2*n+1]
 L = zeros(1, n); % Lower bounds
 U = ones(1, n); % Upper bounds
 
-X0 = zeros(3,n); % Starting points 
+X0 = zeros(3, n); % Starting points
 
-X0(1,:) = xs; % Near origin
-X0(2,:) = 10; % Not near origin 
-X0(3,:) = 100; % Not near origin
-
+X0(1, :) = xs; % Near origin
+X0(2, :) = 10; % Not near origin
+X0(3, :) = 100; % Not near origin
 
 objective = @(x) x; % Identity mapping
 for i = 1:3
-    F0(i,:) = objective(X0(i,:));
+    F0(i, :) = objective(X0(i, :));
 end
 
 nfs = 3; % Points that have been evaluated

--- a/pounders/m/tests/test_bmpts.m
+++ b/pounders/m/tests/test_bmpts.m
@@ -18,8 +18,8 @@ U = ones(1, n); % Upper bounds
 X0 = zeros(3, n); % Starting points
 
 X0(1, :) = xs; % Near origin
-X0(2, :) = 10; % Not near origin
-X0(3, :) = 100; % Not near origin
+X0(2, :) = 10*xs; % Farther from origin
+X0(3, :) = 100*xs; % Colinear
 
 objective = @(x) x; % Identity mapping
 for i = 1:3
@@ -28,6 +28,6 @@ end
 
 nfs = 3; % Points that have been evaluated
 xkin = 1; % Best point's index in X0
-delta = 0.001; % Starting TR radius
+delta = 1e3; % Starting TR radius
 
 [X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, 0, 1);

--- a/pounders/m/tests/test_bmpts.m
+++ b/pounders/m/tests/test_bmpts.m
@@ -1,0 +1,34 @@
+% This tests bmpts.m when it notes that:
+% "Geometry points need to be coordinate directions!"
+
+addpath('../');
+
+nfmax = 100;
+gtol = 1e-13;
+
+n = 2;
+m = n;
+
+xs = 1e-8*ones(1,n);
+
+npmax = 2 * n + 1;  % Maximum number of interpolation points [2*n+1]
+L = zeros(1, n); % Lower bounds
+U = ones(1, n); % Upper bounds
+
+X0 = zeros(3,n); % Starting points 
+
+X0(1,:) = xs; % Near origin
+X0(2,:) = 10; % Not near origin 
+X0(3,:) = 100; % Not near origin
+
+
+objective = @(x) x; % Identity mapping
+for i = 1:3
+    F0(i,:) = objective(X0(i,:));
+end
+
+nfs = 3; % Points that have been evaluated
+xkin = 1; % Best point's index in X0
+delta = 0.001; % Starting TR radius
+
+[X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, 0, 1);

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -67,6 +67,7 @@ def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, prin
     #               = -2 if a valid model produced X[nf] == X[xkin] or (mdec == 0, Fs[nf] == Fs[xkin])
     #               = -3 error if a NaN was encountered
     #               = -4 error in TRSP Solver
+    #               = -5 unable to get model improvement with current parameters
     # xkin    [int] Index of point in X representing approximate minimizer
 
     if hfun is None:
@@ -142,8 +143,10 @@ def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, prin
             if nf + 1 >= nfmax:
                 break
             [_, mp, valid, Gres, Hresdel, Mind] = formquad(X[0 : nf + 1, :], Res[0 : nf + 1, :], delta, xkin, mpmax, Par, False)
-            # [~,np,valid,Gres,Hresdel,Mind] = ...
-            # formquad(X(1:nf,:),Res(1:nf,:),delta,xkin,mpmax,Par,0);
+            if mp < n:
+                X, F, flag = prepare_outputs_before_return(X, F, nf, -5)
+                return
+
         #  1b. Update the quadratic model
         Cres = F[xkin]
         Hres = Hres + Hresdel

--- a/pounders/py/prepare_outputs_before_return.py
+++ b/pounders/py/prepare_outputs_before_return.py
@@ -12,6 +12,8 @@ def prepare_outputs_before_return(X, F, nf, exit_flag):
         print("A NaN was encountered in an objective evaluation. Exiting.")
     elif exit_flag == -2:
         print('Terminating because mdec == 0 with a valid model and no improvement from TRSP solution')
+    elif exit_flag == -5:
+        print('Unable to improve model with current Pars; try dividing Par[2:3] by 10')
     elif exit_flag == 0:
         print('g is sufficiently small')
 


### PR DESCRIPTION
@wildsm I'm trying to cover the branch of `bmpts.m` that is invoked when "Geometry points need to be coordinate directions!"

I'm trying to do so with pounders minimizing the 2-norm squared. I think having a small initial delta and points far outside of the TR would do so. I've tried different starting points near the origin, bounds, and other points in `X0` but it doesn't go down that branch of `bmpts`. 

Thoughts on adjusting this test file?