### PR TITLE
Pounders/optional args

### DIFF
--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -39,7 +39,7 @@
 % printf  [log] 0 No printing to screen
 %               1 Debugging level of output to screen (default)
 %               2 More verbose screen output
-% spsolver [int] Trust-region subproblem solver flag
+% spsolver [int] Trust-region subproblem solver flag (2)
 %
 % Optionally, a user can specify and outer-function that maps the the elements
 % of F to a scalar value (to be minimized). Doing this also requires a function
@@ -69,12 +69,18 @@
 function [X, F, flag, xkin] = ...
     pounders(fun, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver, hfun, combinemodels)
 
-if nargin <= 15
+if ~exist('hfun', 'var')
+    % Use least-squares hfun by default
     addpath('../general_h_funs/');
     hfun = @(F)sum(F.^2);
     combinemodels = @leastsquares;
 end
-
+if ~exist('spsolver', 'var')
+    spsolver = 2; % Use minq5 by default
+end
+if ~exist('printf', 'var')
+    printf = 0; % Don't print by default
+end
 % 0. Check inputs
 [flag, X0, npmax, F0, L, U] = ...
     checkinputss(fun, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U);

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -36,8 +36,8 @@
 % xkin    [int] Index of point in X0 at which to start from (1)
 % L       [dbl] [1-by-n] Vector of lower bounds (-Inf(1,n))
 % U       [dbl] [1-by-n] Vector of upper bounds (Inf(1,n))
-% printf  [log] 0 No printing to screen
-%               1 Debugging level of output to screen (default)
+% printf  [log] 0 No printing to screen (default)
+%               1 Debugging level of output to screen
 %               2 More verbose screen output
 % spsolver [int] Trust-region subproblem solver flag (2)
 %

--- a/pounders/m/tests/test_bounds_and_sp1.m
+++ b/pounders/m/tests/test_bounds_and_sp1.m
@@ -75,6 +75,13 @@ for row = [7, 8]
         end
     end
 end
+
+% Test success without last (optional) arguments to pounders
+minq_location = '../../../../minq/m/minq5/';
+addpath(minq_location);
+
+[X, F, flag, xk_best] = pounders(objective, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U);
+assert(flag == 0, "Test didn't complete");
 end
 
 function [fvec] = calfun_wrapper(x, struct, probtype)

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -8,7 +8,7 @@ from formquad import formquad
 from prepare_outputs_before_return import prepare_outputs_before_return
 
 
-def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf, spsolver, hfun=None, combinemodels=None):
+def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, printf=0, spsolver=2, hfun=None, combinemodels=None):
     # POUNDERS: Practical Optimization Using No Derivatives for sums of Squares
     #   [X,F,flag,xkin] = ...
     #        pounders(fun,X0,n,mpmax,nfmax,gtol,delta,nfs,m,F0,xkin,L,U,printf)
@@ -47,7 +47,7 @@ def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, prin
     # printf  [log] 0 No printing to screen
     #               1 Debugging level of output to screen (default)
     #               2 More verbose screen output
-    # spsolver [int] Trust-region subproblem solver flag
+    # spsolver [int] Trust-region subproblem solver flag (2)
     #
     # Optionally, a user can specify and outer-function that maps the the elements
     # of F to a scalar value (to be minimized). Doing this also requires a function

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -44,8 +44,8 @@ def pounders(fun, X0, n, mpmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, prin
     # xkin    [int] Index of point in X0 at which to start from (1)
     # L       [dbl] [1-by-n] Vector of lower bounds (-Inf(1,n))
     # U       [dbl] [1-by-n] Vector of upper bounds (Inf(1,n))
-    # printf  [log] 0 No printing to screen
-    #               1 Debugging level of output to screen (default)
+    # printf  [log] 0 No printing to screen (default)
+    #               1 Debugging level of output to screen
     #               2 More verbose screen output
     # spsolver [int] Trust-region subproblem solver flag (2)
     #


### PR DESCRIPTION
Allows `printf` and `spsolver` to be optional. Defaults are `printf=0` and `spsolver=2` (i.e., `minq5` for TRSPs).