### PR TITLE
Suggestion: Add setup.py and __init__.py

### DIFF
--- a/pounders/py/setup.py
+++ b/pounders/py/setup.py
@@ -1,0 +1,13 @@
+#!/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(
+    name='pounders',
+    version='0.1.0',
+    description='Optimization using the pounders method',
+    packages = ['pounders'],
+    package_dir = {'pounders': '.'},
+    platforms='any',
+    url='https://github.com/POptUS/IBCDFO/tree/main/pounders'
+    )


### PR DESCRIPTION
This allows users to install `pounders` with:
```
pip install git+https://github.com/RemiLehe/IBCDFO@setup_py#subdirectory=pounders/py
```
After this is merged, `pounders` can then be installed with:
```
pip install git+https://github.com/POptUS/IBCDFO#subdirectory=pounders/py
```

However, the regression and units tests would need to be written slightly differently, in order to adapt to the new paths ; is that something that could be considered?