### PR TITLE
Restoring correct printf behavior

### DIFF
--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -155,6 +155,9 @@ while nf < nfmax
                 jerr(i, j) = (Cres(j) - F(Mind(i), j)) + D * (Gres(:, j) + .5 * Hres(:, :, j) * D');
             end
         end
+        disp(jerr);
+    end
+    if printf
         ierror = norm(IERR ./ max(abs(Fs(Mind, :)'), 0), inf); % Interp. error
         fprintf(progstr, nf, delta, valid, np, Fs(xkin), ng, ierror);
     end % ------------------------------------------------------------------

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -174,6 +174,7 @@ def pounders(fun, X0, n, npmax, nfmax, gtol, delta, nfs, m, F0, xkin, L, U, prin
                     jerr[i, j] = (Cres[j] - F[Mind[i], j]) + D @ (Gres[:, j] + 0.5 * Hres[:, :, j] @ D)
             print(jerr)
             # input("Enter a key and press Enter to continue\n") - Don't uncomment when using Pytest with test_pounders.py
+        if printf:
             ierror = np.linalg.norm(IERR / np.abs(Fs[Mind]), np.inf)
             print(progstr % (nf, delta, valid, mp, Fs[xkin], ng, ierror))
         # 2. Critically test invoked if the projected model gradient is small


### PR DESCRIPTION
When implementing #24 to not always print `jerr`, we also prevented the printing of `progstr` when `printf` is 1 (but not necessarily 2).