### PR TITLE
Speedup choose_generator_set and minimize_affine_envelope

### DIFF
--- a/manifold_sampling/py/choose_generator_set.py
+++ b/manifold_sampling/py/choose_generator_set.py
@@ -23,7 +23,7 @@ def choose_generator_set(X, Hash, gentype, xkin, nf, delta, F, hfun):
                 h_i, _ = hfun(F[xkin], Act_tmp)
                 if h_i[0] <= hxkin[0] or XkDi <= delta2:
                     if i != xkin:
-                        Act_Z_k = np.union1d(Act_Z_k, Act_tmp)
+                        Act_Z_k = np.unique(np.concatenate((Act_Z_k, Act_tmp)), axis=0)
 
     Act_Z_k = np.asarray(Act_Z_k)
     f_k, D_k = hfun(F[xkin], Act_Z_k)

--- a/manifold_sampling/py/choose_generator_set.py
+++ b/manifold_sampling/py/choose_generator_set.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.spatial.distance import cdist
 
 
 def choose_generator_set(X, Hash, gentype, xkin, nf, delta, F, hfun):
@@ -13,15 +14,18 @@ def choose_generator_set(X, Hash, gentype, xkin, nf, delta, F, hfun):
     #             Act_Z_k = np.concatenate((Act_Z_k, Act_tmp))
     if gentype == 3:
         hxkin, _ = hfun(F[xkin, :], Act_Z_k)
-        for i in [ind for ind in range(nf) if ind != xkin]:
-            Act_tmp = Hash[i]
-            h_i, _ = hfun(F[xkin], Act_tmp)
-            if np.linalg.norm(X[xkin] - X[i], ord=np.inf) <= delta * (1 + 1e-8) and h_i[0] <= hxkin[0]:
-                Act_Z_k = np.concatenate((Act_Z_k, Act_tmp))
-            elif np.linalg.norm(X[xkin] - X[i], ord=np.inf) <= delta**2 * (1 + 1e-8) and h_i[0] > hxkin[0]:
-                Act_Z_k = np.concatenate((Act_Z_k, Act_tmp))
+        XkDist = cdist(X[:nf], X[xkin:xkin+1], metric="chebyshev")
+        delta1 = delta * (1 + 1e-8)
+        delta2 = delta ** 2 * (1 + 1e-8)
+        for i, XkDi in enumerate(XkDist):
+            if XkDi <= delta1:
+                Act_tmp = Hash[i]
+                h_i, _ = hfun(F[xkin], Act_tmp)
+                if h_i[0] <= hxkin[0] or XkDi <= delta2:
+                    if i != xkin:
+                        Act_Z_k = np.union1d(Act_Z_k, Act_tmp)
 
-    Act_Z_k = np.unique(Act_Z_k, axis=0)
+    Act_Z_k = np.asarray(Act_Z_k)
     f_k, D_k = hfun(F[xkin], Act_Z_k)
     unique_indices = np.unique(D_k, axis=1, return_index=True)[1]
     D_k = D_k[:, unique_indices]

--- a/manifold_sampling/py/minimize_affine_envelope.py
+++ b/manifold_sampling/py/minimize_affine_envelope.py
@@ -3,24 +3,18 @@ from scipy.optimize import linprog
 
 
 def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subprob_switch):
-    G_k_smaller, cols = np.unique(G_k, axis=1, return_index=True)
 
-    n, p = G_k_smaller.shape
-
+    n, p = G_k.shape
     bk = -(f_bar - f - beta)
-    bk_smaller = bk[cols]
-
-    A = np.hstack((-np.ones((p, 1)), G_k_smaller.T))
+    A = np.hstack((-np.ones((p, 1)), G_k.T))
     ff = np.concatenate((np.array([[1]]), np.zeros((n, 1))))
-    x0 = np.vstack((np.array([np.max(-bk_smaller)]), np.zeros((n, 1))))
 
     assert subprob_switch == "linprog", "Unrecognized subprob_switch"
 
     if subprob_switch == "linprog":
-        options = {"disp": False, "tol": 1e-12}
+        options = {"disp": False, "ipm_optimality_tolerance": 1e-12}
         try:
-            res = linprog(c=ff.flatten(), A_ub=A, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
-            assert res["success"], "We didn't solve this!"
+            res = linprog(c=ff.flatten(), A_ub=A, b_ub=bk, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, method="highs-ipm")
             x = res.x
             duals_g = -1.0 * res.ineqlin.marginals
             duals_u = -1.0 * res.upper.marginals[1:]
@@ -31,15 +25,14 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
             rescaledA = np.zeros_like(A)
             rescaledA[:, 0] = -np.ones(p)
             rescaledA[:, 1:] = A[:, 1:] / normA
-            res = linprog(c=ff.flatten(), A_ub=rescaledA, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
+            res = linprog(c=ff.flatten(), A_ub=rescaledA, b_ub=bk, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, method="highs-ipm")
             assert res["success"], "We didn't solve this!"
             x = res.x
             duals_g = -1.0 * res.ineqlin.marginals
             duals_u = -1.0 * res.upper.marginals[1:] * normA
             duals_l = res.lower.marginals[1:] * normA
 
-    lambda_star = np.zeros(G_k.shape[1])
-    lambda_star[cols] = duals_g
+    lambda_star = duals_g
 
     s = x[1:]
     tau = max(-bk + np.dot(G_k.T, s)) + 0.5 * np.dot(s, np.dot(H, s))


### PR DESCRIPTION
Copy-paste old PR here since it won't let me re-open after I fixed my history issues:

When f is not too expensive or when the function evaluation budget is large, iteration costs can get out of hand. A lot of time spent in ``build_p_models``, which I can only reduce if gradients are given.

But first, I want to confirm that the speedups I implemented don't change anything in your test cases before I propose any structural changes to utilize grads

In ``choose_generator_set.py``:
 - Use ``scipy.spatial.distance.cdist to perform pairwise distance calculations extremely fast
 - Only evaluate ``hfun`` after checking distances, this eliminates hundreds of unnecessary calls per iteration
 - Use ``enumerate()`` instead of ``range()`` in for loop (faster since it doesn't use an iterator object)
 - Use ``np.unique(np.concatenate())`` instead of ``np.concatenate()`` ... ``np.unique()``, it is slightly faster since you never end up with hundreds of redundant rows in ``Act_Z_k``

In ``minimize_affine_envelope.py``:
 - We were spending over 10% of compute time performing constraint reduction, which is unnecessary (I never observe a redundant constraint in my problems) and not recommended for HiGHS IPM solver (faster to solve the problem with redundant constraints than eliminate them)
 - options["tol"] -> options["ipm_optimality_tolerance"]

On my problems, the above changes reduce all significant iteration costs except model building by several orders of magnitude.