### PR TITLE
Handling lp failures more gracefully

### DIFF
--- a/manifold_sampling/py/manifold_sampling_primal.py
+++ b/manifold_sampling/py/manifold_sampling_primal.py
@@ -101,12 +101,16 @@ def manifold_sampling_primal(hfun, Ffun, x0, L, U, nfmax, subprob_switch):
             # Line 7: Find a candidate s_k by solving QP
             Low = np.maximum(L - X[xkin], -delta)
             Upp = np.minimum(U - X[xkin], delta)
-            s_k, tau_k, __, lambda_k = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, H_mm, delta, Low, Upp, H_k, subprob_switch)
+            s_k, tau_k, __, lambda_k, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, H_mm, delta, Low, Upp, H_k, subprob_switch)
+            if lp_fail_flag:
+                return prepare_outputs_before_return(X, F, h, nf, xkin, -2)
 
             # Line 8: Compute stationary measure chi_k
             Low = np.maximum(L - X[xkin], -1.0)
             Upp = np.minimum(U - X[xkin], 1.0)
-            __, __, chi_k, __ = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, np.zeros((n, n)), delta, Low, Upp, np.zeros((G_k.shape[1], n + 1, n + 1)), subprob_switch)
+            __, __, chi_k, __, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, np.zeros((n, n)), delta, Low, Upp, np.zeros((G_k.shape[1], n + 1, n + 1)), subprob_switch)
+            if lp_fail_flag:
+                return prepare_outputs_before_return(X, F, h, nf, xkin, -2)
 
             # Lines 9-11: Convergence test: tiny master model gradient and tiny delta
             if chi_k <= tol["gtol"] and delta <= tol["mindelta"]:

--- a/manifold_sampling/py/minimize_affine_envelope.py
+++ b/manifold_sampling/py/minimize_affine_envelope.py
@@ -20,7 +20,7 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
         options = {"disp": False, "maxiter": (n * p) ** 3, "ipm_optimality_tolerance": 1e-12}
         try:
             res = linprog(c=ff.flatten(), A_ub=A, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
-            assert res["success"], "We didn't solve this!"
+            assert res["success"], "Error in minimize_affine_envelope. Trying rescaling now."
             x = res.x
             duals_g = -1.0 * res.ineqlin.marginals
             duals_u = -1.0 * res.upper.marginals[1:]
@@ -32,7 +32,8 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
             rescaledA[:, 0] = -np.ones(p)
             rescaledA[:, 1:] = A[:, 1:] / normA
             res = linprog(c=ff.flatten(), A_ub=rescaledA, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
-            assert res["success"], "We didn't solve this!"
+            return 0, 0, 0, 0, True
+
             x = res.x
             duals_g = -1.0 * res.ineqlin.marginals
             duals_u = -1.0 * res.upper.marginals[1:] * normA
@@ -52,4 +53,4 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
 
     chi = np.linalg.norm(np.dot(G_k, lambda_star) - duals_l + duals_u) + np.dot(bk, lambda_star) - np.dot(Low, duals_l) + np.dot(Upp, duals_u)
 
-    return s, tau, chi, lambda_star
+    return s, tau, chi, lambda_star, False

--- a/manifold_sampling/py/prepare_outputs_before_return.py
+++ b/manifold_sampling/py/prepare_outputs_before_return.py
@@ -8,6 +8,8 @@ def prepare_outputs_before_return(X, F, h, nf, xkin, exit_flag):
     F = F[: nf + 1]
     h = h[: nf + 1]
 
+    if exit_flag == -2:
+        print("MSP: Minimize affine envelope subproblem failed. Problem likely unbounded or poorly scaled.")
     if exit_flag == -1:
         print("MSP: Model building failed. Empty Gres.")
     elif exit_flag == 0:


### PR DESCRIPTION
Rather than asserting (crashing) when the resource/rescaled LP in `minimize_affine_envelope.py` is also not successfully solved, we can exit MSP gracefully.