### PR TITLE
Indexing error

### DIFF
--- a/manifold_sampling/py/choose_generator_set.py
+++ b/manifold_sampling/py/choose_generator_set.py
@@ -14,7 +14,7 @@ def choose_generator_set(X, Hash, gentype, xkin, nf, delta, F, hfun):
     #             Act_Z_k = np.concatenate((Act_Z_k, Act_tmp))
     if gentype == 3:
         hxkin, _ = hfun(F[xkin, :], Act_Z_k)
-        XkDist = cdist(X[:nf], X[xkin : xkin + 1], metric="chebyshev")
+        XkDist = cdist(X[:nf + 1], X[xkin : xkin + 1], metric="chebyshev")
         delta1 = delta * (1 + 1e-8)
         delta2 = min(1, delta) ** 2 * (1 + 1e-8)
 

--- a/manifold_sampling/py/choose_generator_set.py
+++ b/manifold_sampling/py/choose_generator_set.py
@@ -14,7 +14,7 @@ def choose_generator_set(X, Hash, gentype, xkin, nf, delta, F, hfun):
     #             Act_Z_k = np.concatenate((Act_Z_k, Act_tmp))
     if gentype == 3:
         hxkin, _ = hfun(F[xkin, :], Act_Z_k)
-        XkDist = cdist(X[:nf + 1], X[xkin : xkin + 1], metric="chebyshev")
+        XkDist = cdist(X[: nf + 1], X[xkin : xkin + 1], metric="chebyshev")
         delta1 = delta * (1 + 1e-8)
         delta2 = min(1, delta) ** 2 * (1 + 1e-8)
 


### PR DESCRIPTION
Since `nf` is the index of the last evaluated point, we need to index to `nf+1` to have `nf` included. 

This was fixed in `develop` when #138 was created, but not #116. (So the issue had been fixed in #132, commit https://github.com/POptUS/IBCDFO/pull/132/commits/a66f32b439bd4f75afa989dab2c0b725d7efe79f, but then forgotten)