### PR TITLE
Only returning with error/exit flag when the second call fails

### DIFF
--- a/manifold_sampling/py/manifold_sampling_primal.py
+++ b/manifold_sampling/py/manifold_sampling_primal.py
@@ -50,7 +50,9 @@ from .check_inputs_and_initialize import check_inputs_and_initialize
 from .choose_generator_set import choose_generator_set
 from .minimize_affine_envelope import minimize_affine_envelope
 from .prepare_outputs_before_return import prepare_outputs_before_return
-
+# import matlab.engine
+# eng = matlab.engine.start_matlab()
+eng = []
 
 def manifold_sampling_primal(hfun, Ffun, x0, L, U, nfmax, subprob_switch):
     # Deduce p from evaluating Ffun at x0
@@ -101,14 +103,14 @@ def manifold_sampling_primal(hfun, Ffun, x0, L, U, nfmax, subprob_switch):
             # Line 7: Find a candidate s_k by solving QP
             Low = np.maximum(L - X[xkin], -delta)
             Upp = np.minimum(U - X[xkin], delta)
-            s_k, tau_k, __, lambda_k, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, H_mm, delta, Low, Upp, H_k, subprob_switch)
+            s_k, tau_k, __, lambda_k, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, H_mm, delta, Low, Upp, H_k, subprob_switch, eng)
             if lp_fail_flag:
                 return prepare_outputs_before_return(X, F, h, nf, xkin, -2)
 
             # Line 8: Compute stationary measure chi_k
             Low = np.maximum(L - X[xkin], -1.0)
             Upp = np.minimum(U - X[xkin], 1.0)
-            __, __, chi_k, __, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, np.zeros((n, n)), delta, Low, Upp, np.zeros((G_k.shape[1], n + 1, n + 1)), subprob_switch)
+            __, __, chi_k, __, lp_fail_flag = minimize_affine_envelope(h[xkin], f_bar, beta, G_k, np.zeros((n, n)), delta, Low, Upp, np.zeros((G_k.shape[1], n + 1, n + 1)), subprob_switch, eng)
             if lp_fail_flag:
                 return prepare_outputs_before_return(X, F, h, nf, xkin, -2)
 

--- a/manifold_sampling/py/manifold_sampling_primal.py
+++ b/manifold_sampling/py/manifold_sampling_primal.py
@@ -57,6 +57,7 @@ from .prepare_outputs_before_return import prepare_outputs_before_return
 # eng = matlab.engine.start_matlab()
 eng = []
 
+
 def manifold_sampling_primal(hfun, Ffun, x0, L, U, nfmax, subprob_switch):
     # Deduce p from evaluating Ffun at x0
     try:

--- a/manifold_sampling/py/manifold_sampling_primal.py
+++ b/manifold_sampling/py/manifold_sampling_primal.py
@@ -50,6 +50,9 @@ from .check_inputs_and_initialize import check_inputs_and_initialize
 from .choose_generator_set import choose_generator_set
 from .minimize_affine_envelope import minimize_affine_envelope
 from .prepare_outputs_before_return import prepare_outputs_before_return
+
+# # You'll need to uncomment the following two, and not have `eng = []` if you
+# # want to use matlab's linprog in minimize_affine_envelope
 # import matlab.engine
 # eng = matlab.engine.start_matlab()
 eng = []

--- a/manifold_sampling/py/minimize_affine_envelope.py
+++ b/manifold_sampling/py/minimize_affine_envelope.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.optimize import linprog
+
 # import matlab # You'll need to uncomment this if you are going to use matlab's linprog below.
 
 
@@ -27,7 +28,7 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
             duals_u = -1.0 * res.upper.marginals[1:]
             duals_l = res.lower.marginals[1:]
 
-            # # Prepare your data for MATLAB. MATLAB expects column-major order, 
+            # # Prepare your data for MATLAB. MATLAB expects column-major order,
             # # and the MATLAB Engine API for Python requires MATLAB types for some data
             # c_matlab = matlab.double(ff.flatten().tolist())
             # A_matlab = matlab.double(A.tolist())

--- a/manifold_sampling/py/minimize_affine_envelope.py
+++ b/manifold_sampling/py/minimize_affine_envelope.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.optimize import linprog
-import matlab
+# import matlab # You'll need to uncomment this if you are going to use matlab's linprog below.
 
 
 def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subprob_switch, eng):

--- a/manifold_sampling/py/minimize_affine_envelope.py
+++ b/manifold_sampling/py/minimize_affine_envelope.py
@@ -1,8 +1,9 @@
 import numpy as np
 from scipy.optimize import linprog
+import matlab
 
 
-def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subprob_switch):
+def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subprob_switch, eng):
     G_k_smaller, cols = np.unique(G_k, axis=1, return_index=True)
 
     n, p = G_k_smaller.shape
@@ -25,19 +26,62 @@ def minimize_affine_envelope(f, f_bar, beta, G_k, H, delta, Low, Upp, H_k, subpr
             duals_g = -1.0 * res.ineqlin.marginals
             duals_u = -1.0 * res.upper.marginals[1:]
             duals_l = res.lower.marginals[1:]
-        except Exception as e:
-            print(e)
-            normA = np.linalg.norm(A[:, 1:])
-            rescaledA = np.zeros_like(A)
-            rescaledA[:, 0] = -np.ones(p)
-            rescaledA[:, 1:] = A[:, 1:] / normA
-            res = linprog(c=ff.flatten(), A_ub=rescaledA, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
-            return 0, 0, 0, 0, True
 
-            x = res.x
-            duals_g = -1.0 * res.ineqlin.marginals
-            duals_u = -1.0 * res.upper.marginals[1:] * normA
-            duals_l = res.lower.marginals[1:] * normA
+            # # Prepare your data for MATLAB. MATLAB expects column-major order, 
+            # # and the MATLAB Engine API for Python requires MATLAB types for some data
+            # c_matlab = matlab.double(ff.flatten().tolist())
+            # A_matlab = matlab.double(A.tolist())
+            # b_matlab = matlab.double(bk_smaller.tolist())
+            # lb_matlab = matlab.double([float('-inf')] + Low.tolist())
+            # ub_matlab = matlab.double([float('inf')] + Upp.tolist())
+            # # options_matlab = eng.optimoptions('linprog', 'Algorithm', 'dual-simplex', 'Display', 'None')
+            # options_matlab = eng.optimoptions('linprog', 'Display', 'None')
+            # result = eng.linprog(c_matlab, A_matlab, b_matlab, matlab.double([]), matlab.double([]), lb_matlab, ub_matlab, options_matlab, nargout=5)
+
+            # if result[2] == 1: # successful termination
+            #     x = np.array([item for sublist in result[0] for item in sublist])
+            #     duals_g = np.array([result[4]["ineqlin"]]).squeeze()
+            #     duals_u = np.array([item for sublist in result[4]["upper"] for item in sublist])[1:]
+            #     duals_l = np.array([item for sublist in result[4]["lower"] for item in sublist])[1:]
+            # else:
+            #     duals_g = np.zeros(p)
+            #     duals_g[0] = 1.0
+            #     duals_l = np.zeros(n)
+            #     duals_u = np.zeros(n)
+            #     x = x0.squeeze()
+
+        except Exception as first_exception:
+            print(first_exception)
+            try:
+                normA = np.linalg.norm(A[:, 1:])
+                rescaledA = np.zeros_like(A)
+                rescaledA[:, 0] = -np.ones(p)
+                rescaledA[:, 1:] = A[:, 1:] / normA
+                res = linprog(c=ff.flatten(), A_ub=rescaledA, b_ub=bk_smaller, bounds=list(zip([None] + list(Low), [None] + list(Upp))), options=options, x0=x0, method="highs-ipm")
+                assert res["success"], "Error in minimize_affine_envelope. Trying rescaling now."
+
+                x = res.x
+                duals_g = -1.0 * res.ineqlin.marginals
+                duals_u = -1.0 * res.upper.marginals[1:]
+                duals_l = res.lower.marginals[1:]
+
+                # result = eng.linprog(c_matlab, matlab.double(rescaledA.tolist()), b_matlab, matlab.double([]), matlab.double([]), lb_matlab, ub_matlab, x0, options_matlab, nargout=5)
+
+                # if result[2] == 1: # successful termination
+                #     x = np.array([item for sublist in result[0] for item in sublist])
+                #     duals_g = np.array([result[4]["ineqlin"]]).squeeze()
+                #     duals_u = np.array([item for sublist in result[4]["upper"] for item in sublist])[1:]
+                #     duals_l = np.array([item for sublist in result[4]["lower"] for item in sublist])[1:]
+                # else:
+                #     duals_g = np.zeros(p)
+                #     duals_g[0] = 1.0
+                #     duals_l = np.zeros(n)
+                #     duals_u = np.zeros(n)
+                #     x = x0.squeeze()
+
+            except Exception as second_exception:
+                print(second_exception)
+                return 0, 0, 0, 0, True
 
     lambda_star = np.zeros(G_k.shape[1])
     lambda_star[cols] = duals_g


### PR DESCRIPTION
There was an error where minimize_affine_envelope.py was returning with an exitflag of 1, even if the rescaled system solved correctly. 

In debugging some other issues, I tried using the matlab linprog solver... but it actually did worse, at least for the options I was using. Nevertheless, I thought we might want to save the interface for the future.