### PR TITLE
Concurrent pounders

### DIFF
--- a/pounders/py/formquad.py
+++ b/pounders/py/formquad.py
@@ -51,8 +51,8 @@ def formquad(X, F, delta, xk_in, np_max, Pars, vf):
     scale_mat[np.diag_indices(n)] = 1
     inds_to_use_in_H = np.triu_indices(n)
 
-    assert isinstance(np_max, (int,np.integer)), "Must be an integer"
-    assert isinstance(xk_in, (int,np.integer)), "Must be an integer"
+    assert isinstance(np_max, (int, np.integer)), "Must be an integer"
+    assert isinstance(xk_in, (int, np.integer)), "Must be an integer"
 
     D = (X[:nf] - X[xk_in]) / delta
     Nd = np.linalg.norm(D, 2, axis=1)

--- a/pounders/py/formquad.py
+++ b/pounders/py/formquad.py
@@ -51,8 +51,8 @@ def formquad(X, F, delta, xk_in, np_max, Pars, vf):
     scale_mat[np.diag_indices(n)] = 1
     inds_to_use_in_H = np.triu_indices(n)
 
-    assert isinstance(np_max, int), "Must be an integer"
-    assert isinstance(xk_in, int), "Must be an integer"
+    assert isinstance(np_max, (int,np.integer)), "Must be an integer"
+    assert isinstance(xk_in, (int,np.integer)), "Must be an integer"
 
     D = (X[:nf] - X[xk_in]) / delta
     Nd = np.linalg.norm(D, 2, axis=1)

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -32,6 +32,7 @@ def _default_prior():
 
     return Prior
 
+
 def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Options=None, Model=None, par=1):
     """
     POUNDERS: Practical Optimization Using No Derivatives for sums of Squares
@@ -177,8 +178,8 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
             X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -1, Xtype, Group)
             return X, F, hF, flag, xk_in, Xtype, Group
         F[nf] = F_0
-        Xtype[nf] = 0 # Initial point
-        Group[nf] = gnf; 
+        Xtype[nf] = 0  # Initial point
+        Group[nf] = gnf
         if np.any(np.isnan(F[nf])):
             X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -3, Xtype, Group)
             return X, F, hF, flag, xk_in, Xtype, Group
@@ -195,7 +196,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
     for i in range(nf + 1):
         hF[i] = hfun(F[i])
 
-    gnf += 1;
+    gnf += 1
     Res = np.zeros(np.shape(F))
     Cres = F[xk_in]
     Hres = np.zeros((n, n, m))
@@ -214,8 +215,9 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                 nf += 1
                 X[nf] = np.minimum(Upp, np.maximum(Low, X[xk_in] + Mdir[i, :]))
                 F[nf] = Ffun(X[nf])
-                Xtype[nf] = 1; # Iterpolation set point
-                Group[nf] = gnf;
+                Xtype[nf] = 1
+                # Iterpolation set point
+                Group[nf] = gnf
                 if np.any(np.isnan(F[nf])):
                     X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -3, Xtype, Group)
                     return X, F, hF, flag, xk_in, Xtype, Group
@@ -224,7 +226,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                     print("%4i   Geometry point  %11.5e\n" % (nf, hF[nf]))
                 D = Mdir[i, :]
                 Res[nf, :] = (F[nf, :] - Cres) - 0.5 * D @ np.tensordot(D.T, Hres, 1)
-            gnf += 1;
+            gnf += 1
             if nf + 1 >= nf_max:
                 break
             [_, mp, valid, Gres, Hresdel, Mind] = formquad(X[0 : nf + 1, :], Res[0 : nf + 1, :], delta, xk_in, Model["np_max"], Model["Par"], False)
@@ -268,15 +270,15 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                     nf += 1
                     X[nf] = np.minimum(Upp, np.maximum(Low, X[xk_in] + Mdir[i, :]))
                     F[nf] = Ffun(X[nf])
-                    Xtype[nf] = 2 # Criticality test point
-                    Group[nf] = gnf;
+                    Xtype[nf] = 2  # Criticality test point
+                    Group[nf] = gnf
                     if np.any(np.isnan(F[nf])):
                         X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -3, Xtype, Group)
                         return X, F, flag, xk_in, Xtype, Group
                     hF[nf] = hfun(F[nf])
                     if printf:
                         print("%4i   Critical point  %11.5e\n" % (nf, hF[nf]))
-                gnf += 1;
+                gnf += 1
                 if nf + 1 >= nf_max:
                     break
                 # Recalculate gradient based on a MFN model
@@ -292,12 +294,12 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         # # do_extra_TRSP_evals:
 
         # 3. Solve the subproblem min{G.T * s + 0.5 * s.T * H * s : Lows <= s <= Upps }
-        steps = np.zeros((par,n))
+        steps = np.zeros((par, n))
         step_norms = np.zeros(par)
         mdecs = np.zeros(par)
         enter_step_four = np.zeros(par)
-        # deltas = [(2**i)*delta for i in np.arange(np.ceil(-par/2),np.ceil(par/2))] 
-        deltas = [(2.0**i)*delta for i in np.arange(-par+1,1)]
+        # deltas = [(2**i)*delta for i in np.arange(np.ceil(-par/2),np.ceil(par/2))]
+        deltas = [(2.0**i) * delta for i in np.arange(-par + 1, 1)]
         # deltas = [delta]*par
         for ii, delta_extra in enumerate(deltas):
             Lows = np.maximum(Low - X[xk_in], -delta_extra * np.ones((np.shape(Low))))
@@ -336,15 +338,15 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                 nf += 1
                 X[nf] = Xsp
                 F[nf] = Ffun(X[nf])
-                Xtype[nf] = 3 # TRSP point
-                Group[nf] = gnf;
+                Xtype[nf] = 3  # TRSP point
+                Group[nf] = gnf
                 if np.any(np.isnan(F[nf])):
                     X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -3, Xtype, Group)
                     return X, F, hF, flag, xk_in, Xtype, Group
                 hF[nf] = hfun(F[nf])
-            gnf += 1;
-            best_ind = np.argmin(hF[nf+1-par:nf+1])
-            ind_in_h = nf+1-par+best_ind
+            gnf += 1
+            best_ind = np.argmin(hF[nf + 1 - par : nf + 1])
+            ind_in_h = nf + 1 - par + best_ind
 
             if mdecs[best_ind] != 0:
                 rho = (hF[ind_in_h] - hF[xk_in]) / mdecs[best_ind]
@@ -389,7 +391,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                 # Plus directions
                 [Mdir1, mp1] = bmpts(X[xk_in], Mdir[0 : n - mp, :], Low, Upp, delta, Model["Par"][2])
                 [Mdir2, mp2] = bmpts(X[xk_in], -Mdir[0 : n - mp, :], Low, Upp, delta, Model["Par"][2])
-                assert mp1==mp2, "How aren't these equal?"
+                assert mp1 == mp2, "How aren't these equal?"
                 for i in range(n - mp1):
                     D = Mdir1[i, :]
                     Res[i, 0] = D @ (G + 0.5 * H @ D.T)
@@ -399,30 +401,30 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                     Res[i, 0] = D @ (G + 0.5 * H @ D.T)
                 vals2 = Res[: n - mp2, 0:1].copy()
 
-                keepers = np.ones(n-mp1)
-                for i in range(n-mp1):
+                keepers = np.ones(n - mp1)
+                for i in range(n - mp1):
                     if vals2[i] < vals[i]:
                         vals[i] = vals2[i]
                         keepers[i] = 2
 
-                inds = np.argsort(vals,axis=0)
+                inds = np.argsort(vals, axis=0)
 
                 Xsps = Mdir1[inds, :]
-                for i in range(n-mp1):
+                for i in range(n - mp1):
                     if keepers[i] == 2:
-                        Xsps[i] = Mdir2[inds[i],:]
+                        Xsps[i] = Mdir2[inds[i], :]
                 # Xsps = [Mdir1[inds[0], :]]
                 # if vals2[inds[0]]<vals[inds[0]]:
                 #     Xsps[0] = Mdir2[inds[i],:]
 
-                for ii,Xsp in enumerate(Xsps):
+                for ii, Xsp in enumerate(Xsps):
                     if ii >= par:
                         break
                     nf += 1
                     X[nf] = np.minimum(Upp, np.maximum(Low, X[xk_in] + Xsp))  # Temp safeguard
                     F[nf] = Ffun(X[nf])
-                    Xtype[nf] = 4 # Model-building point
-                    Group[nf] = gnf; 
+                    Xtype[nf] = 4  # Model-building point
+                    Group[nf] = gnf
                     if np.any(np.isnan(F[nf])):
                         X, F, hF, flag, Xtype, Group = prepare_outputs_before_return(X, F, hF, nf, -3, Xtype, Group)
                         return X, F, hF, flag, xk_in, Xtype, Group
@@ -439,8 +441,8 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
                         # Don't actually use
                         for j in range(m):
                             Gres[:, j] = Gres[:, j] + Hres[:, :, j] @ D.T
-                gnf += 1;
+                gnf += 1
     if printf:
         print("Number of function evals exceeded")
     flag = ng
-    return X[:nf+1], F[:nf+1], hF[:nf+1], flag, xk_in, Xtype[:nf+1], Group[:nf+1]
+    return X[: nf + 1], F[: nf + 1], hF[: nf + 1], flag, xk_in, Xtype[: nf + 1], Group[: nf + 1]

--- a/pounders/py/prepare_outputs_before_return.py
+++ b/pounders/py/prepare_outputs_before_return.py
@@ -16,7 +16,7 @@ def prepare_outputs_before_return(X, F, hF, nf, exit_flag):
     elif exit_flag == -5:
         print("Unable to improve model with current Pars; try dividing Par[2:3] by 10")
     elif exit_flag == -1:
-        print("Number of residuals in output of fun does not match supplied m. Exiting. ")
+        print("Number of residuals in output of fun does not match supplied m. Exiting.")
     elif exit_flag == 0:
         print("g is sufficiently small")
 

--- a/pounders/py/prepare_outputs_before_return.py
+++ b/pounders/py/prepare_outputs_before_return.py
@@ -1,4 +1,4 @@
-def prepare_outputs_before_return(X, F, hF, nf, exit_flag):
+def prepare_outputs_before_return(X, F, hF, nf, exit_flag, Xtype, Group):
     """
     This function is called to cleanup X and F, set the exit value, and display
     reason for exiting.
@@ -6,6 +6,8 @@ def prepare_outputs_before_return(X, F, hF, nf, exit_flag):
     X = X[: nf + 1]
     F = F[: nf + 1]
     hF = hF[: nf + 1]
+    Xtype = Xtype[: nf + 1]
+    Group = Group[: nf + 1]
 
     if exit_flag == -4:
         print("A minq input error occurred. Exiting.")
@@ -20,4 +22,4 @@ def prepare_outputs_before_return(X, F, hF, nf, exit_flag):
     elif exit_flag == 0:
         print("g is sufficiently small")
 
-    return X, F, hF, exit_flag
+    return X, F, hF, exit_flag, Xtype, Group

--- a/pounders/py/tests/concurrency_test.py
+++ b/pounders/py/tests/concurrency_test.py
@@ -1,0 +1,91 @@
+"""
+A test of pounders with concurrent evaluations 
+"""
+
+import os,sys
+import pickle
+import unittest
+from mpi4py import MPI
+
+import ibcdfo.pounders as pdrs
+import numpy as np
+import scipy as sp
+from calfun import calfun
+from dfoxs import dfoxs
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+if not os.path.exists("benchmark_results"):
+    os.makedirs("benchmark_results")
+
+dfo = np.loadtxt("dfo.dat")
+
+spsolver = 2
+g_tol = 1e-13
+factor = 10
+printf = False
+combinemodels = pdrs.identity_combine
+hfun = lambda F: np.squeeze(F)
+Opts = {"spsolver": 1, "hfun": hfun, "combinemodels": combinemodels}
+
+for row, (nprob, n, m, factor_power) in enumerate(dfo):
+    par = 1
+    n = int(n)
+    m_for_Ffun_only = int(m)
+    nf_max = 20*(n+1)*par
+
+    filename = f"./benchmark_results/pounders4py_nf_max={nf_max}_prob={row}_spsolver={spsolver}_hfun=default_par={par}.mat"
+    if row % size == rank and not os.path.isfile(filename):
+        print(filename, flush=True)
+
+        def Ffun(y):
+            out = calfun(y, m_for_Ffun_only, int(nprob), "smooth", 0, num_outs=2)[1]
+            return np.squeeze(out)
+
+        X_0 = dfoxs(n, nprob, int(factor**factor_power))
+        Low = -np.inf * np.ones((1, n))  # 1-by-n Vector of lower bounds [zeros(1, n)]
+        Upp = np.inf * np.ones((1, n))  # 1-by-n Vector of upper bounds [ones(1, n)]
+        nfs = 1
+        F_init = np.zeros((1, m_for_Ffun_only))
+        F_init[0] = Ffun(X_0)
+        xind = 0
+        delta = 0.1
+
+        Prior = {"X_init": X_0, "F_init": F_init, "nfs": nfs, "xk_in": xind}
+
+        Results = {}
+
+        Prior = {"nfs": 1, "F_init": F_init, "X_init": X_0, "xk_in": xind}
+
+        [X, F, hF, flag, xk_best, Xtype, Group, extra_evals] = pdrs.pounders(Ffun, X_0, n, nf_max, g_tol, delta, m_for_Ffun_only, Low, Upp, Prior=Prior, Options=Opts, Model={}, par=par)
+
+        evals = F.shape[0]
+
+        assert flag != 1, "pounders failed"
+        # assert hfun(F[0]) > hfun(F[xk_best]), "No improvement found"
+        # assert X.shape[0] <= nf_max + nfs, "POUNDERs grew the size of X"
+
+        # if flag == 0:
+        #     assert evals <= nf_max + nfs, "POUNDERs evaluated more than nf_max evaluations"
+        # elif flag != -4 and flag != -2 and flag != -5:
+        #     assert evals == nf_max + nfs, "POUNDERs didn't use nf_max evaluations"
+
+        Results["pounders4py_" + str(row)] = {}
+        Results["pounders4py_" + str(row)]["alg"] = "pounders4py"
+        Results["pounders4py_" + str(row)]["problem"] = "problem " + str(row) + " from More/Wild"
+        Results["pounders4py_" + str(row)]["Fvec"] = F
+        Results["pounders4py_" + str(row)]["H"] = hF
+        Results["pounders4py_" + str(row)]["X"] = X
+        Results["pounders4py_" + str(row)]["Xtype"] = Xtype
+        Results["pounders4py_" + str(row)]["Group"] = Group
+        Results["pounders4py_" + str(row)]["extra_evals"] = extra_evals
+
+        sp.io.savemat(filename, Results)
+
+        # Remove the .mat extension and save to Python data file using pickle
+        filename_pkl = filename.replace('.mat', '.pkl')
+        with open(filename_pkl, 'wb') as file:
+                pickle.dump(Results, file)
+

--- a/pounders/py/tests/concurrency_test.py
+++ b/pounders/py/tests/concurrency_test.py
@@ -2,16 +2,17 @@
 A test of pounders with concurrent evaluations 
 """
 
-import os, sys
+import os
 import pickle
+import sys
 import unittest
-from mpi4py import MPI
 
 import ibcdfo.pounders as pdrs
 import numpy as np
 import scipy as sp
 from calfun import calfun
 from dfoxs import dfoxs
+from mpi4py import MPI
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()

--- a/pounders/py/tests/concurrency_test.py
+++ b/pounders/py/tests/concurrency_test.py
@@ -2,7 +2,7 @@
 A test of pounders with concurrent evaluations 
 """
 
-import os,sys
+import os, sys
 import pickle
 import unittest
 from mpi4py import MPI
@@ -21,7 +21,7 @@ if not os.path.exists("benchmark_results"):
     os.makedirs("benchmark_results")
 
 dfo = np.loadtxt("dfo.dat")
-dfo = dfo[[0, 1, 2, 7, 18, 22, 35, 44, 49, 50],:] # A somewhat random subset of functions
+dfo = dfo[[0, 1, 2, 7, 18, 22, 35, 44, 49, 50], :]  # A somewhat random subset of functions
 
 spsolver = 2
 g_tol = 1e-13
@@ -34,7 +34,7 @@ for row, (nprob, n, m, factor_power) in enumerate(dfo):
     par = 1
     n = int(n)
     m_for_Ffun_only = int(m)
-    nf_max = 20*(n+1)*par
+    nf_max = 20 * (n + 1) * par
 
     filename = f"./benchmark_results/pounders4py_nf_max={nf_max}_prob={row}_spsolver={spsolver}_hfun=default_par={par}.mat"
     if row % size == rank and not os.path.isfile(filename):
@@ -84,7 +84,6 @@ for row, (nprob, n, m, factor_power) in enumerate(dfo):
         sp.io.savemat(filename, Results)
 
         # Remove the .mat extension and save to Python data file using pickle
-        filename_pkl = filename.replace('.mat', '.pkl')
-        with open(filename_pkl, 'wb') as file:
-                pickle.dump(Results, file)
-
+        filename_pkl = filename.replace(".mat", ".pkl")
+        with open(filename_pkl, "wb") as file:
+            pickle.dump(Results, file)


### PR DESCRIPTION
To help others orient themselves to this PR:
- We are first considering python
- Let `conc` be the requested concurrency level
- Before any assumed `Ffun` changes, this PR mocks batching of evaluations in Pounders
- This mock batching happens by storing a `Group` number and `Xtype` for each point
- We require `nf_max` to be a multiple of the requested concurrency level. 
- Grouping can happen in 4 places. 
  - The "interpolation step" (`Xtype 1`)
  - The "criticality step" (`Xtype 2`)
  - The "TRSP step" (`Xtype 3`)
  - "Model improving" (`Xtype 4`)
- For the first two places, there is no attempt to ensure only `conc` points appear. We assume `np_max` is chosen to align with `conc`
- For the "TRSP step", TRSPs are solved for `delta`, `delta(1/2)`,..., `delta(1/2^conc-1)`. If any TRSP solutions satisfy the conditions for being evaluated, all are evaluated
- For the "Model Improving", first the `Mdir` and `-Mdir` directions from `formquad` are considered. The best (positive or negative) from each direction are considered by comparing against the model. Only the `conc` best directions will be evaluated. (But fewer than `conc` could be evaluated.)