### PR TITLE
Having issues with 21

### DIFF
--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14]
-        matlab-release: ["R2021a", "R2021b", "R2022a", "R2022b", "R2023a", "R2023b", "R2024a"]
+        matlab-release: ["R2022a", "R2022b", "R2023a", "R2023b", "R2024a"]
         exclude:
           # Failing with a possible issue outside IBCDFO (Issue #157)
           - os: macos-14


### PR DESCRIPTION
@jared321 we are having issues with Mac+ Matlab21 on github. I think it's okay to drop. Example issues:

https://github.com/POptUS/IBCDFO/actions/runs/11109072104/job/30863553592

But I note that this PR has all green checks.