### PR TITLE
The displayed value for the initial-point in matlab is an error.

### DIFF
--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -86,7 +86,7 @@ if nfs == 0 % Need to do the first evaluation
         return
     end
     if printf
-        fprintf('%4i    Initial point  %11.5e\n', nf, sum(F(nf, :).^2));
+        fprintf('%4i    Initial point  %11.5e\n', nf, hfun(F(nf, :)));
     end
 else % Have other function values around
     X = [X0(1:nfs, :); zeros(nf_max, n)]; % Stores the point locations


### PR DESCRIPTION
This is only a cosmetic bugfix. The value being used was correct, but the print was assuming a 2-norm hfun.