### PR TITLE
Testing/sum squared

### DIFF
--- a/manifold_sampling/m/tests/Testmanifoldsampling.m
+++ b/manifold_sampling/m/tests/Testmanifoldsampling.m
@@ -20,6 +20,7 @@ classdef Testmanifoldsampling < matlab.unittest.TestCase
 
         function shortTests(testCase)
             test_failing_objective;
+            test_manifold_sampling_simple;
         end
 
         function longTest(testCase)

--- a/manifold_sampling/m/tests/test_manifold_sampling_simple.m
+++ b/manifold_sampling/m/tests/test_manifold_sampling_simple.m
@@ -1,0 +1,46 @@
+% This tests a single-manifold case for manifold sampling. 
+
+function [] = test_manifold_sampling_simple()
+
+[here_path, ~, ~] = fileparts(mfilename('fullpath'));
+oldpath = addpath(fullfile(here_path, '..'));
+addpath(fullfile(here_path, '..', 'h_examples'));
+
+nfmax = 300;
+factor = 10;
+
+hfun = @sum_squared;
+subprob_switch = 'linprog';
+
+load dfo.dat;
+
+for row = [1, 2]
+    nprob = dfo(row, 1);
+    n = dfo(row, 2);
+    m = dfo(row, 3);
+    factor_power = dfo(row, 4);
+
+    BenDFO.nprob = nprob;
+    BenDFO.n = n;
+    BenDFO.m = m;
+
+    LB = -5000 * ones(1, n);
+    UB = 5000 * ones(1, n);
+
+    xs = dfoxs(n, nprob, factor^factor_power);
+
+    Ffun = @(x)calfun_wrapper(x, BenDFO, 'smooth');
+    x0 = xs';
+
+    [~, ~, hF, xkin, ~] = manifold_sampling_primal(hfun, Ffun, x0, LB, UB, nfmax, subprob_switch);
+    if row == 1 || row == 2
+        assert(hF(xkin) <= 36.0 + 1e-8, "Not within 1e-8 of known minima")
+    end
+end
+path(oldpath);
+end
+
+function [fvec] = calfun_wrapper(x, struct, probtype)
+    [~, fvec, ~] = calfun(x, struct, probtype);
+    fvec = fvec';
+end

--- a/manifold_sampling/m/tests/test_manifold_sampling_simple.m
+++ b/manifold_sampling/m/tests/test_manifold_sampling_simple.m
@@ -1,4 +1,4 @@
-% This tests a single-manifold case for manifold sampling. 
+% This tests a single-manifold case for manifold sampling.
 
 function [] = test_manifold_sampling_simple()
 
@@ -34,7 +34,7 @@ for row = [1, 2]
 
     [~, ~, hF, xkin, ~] = manifold_sampling_primal(hfun, Ffun, x0, LB, UB, nfmax, subprob_switch);
     if row == 1 || row == 2
-        assert(hF(xkin) <= 36.0 + 1e-8, "Not within 1e-8 of known minima")
+        assert(hF(xkin) <= 36.0 + 1e-8, "Not within 1e-8 of known minima");
     end
 end
 path(oldpath);


### PR DESCRIPTION
As noted in #183, we were not testing the `sum_squared.m` file in the manifold sampling h_examples. 

`sum_squared` is not a standard example for using manifold sampling as there is a smooth hfun, having only one Hash. I will note that manifold sampling is slow in optimizing the (say) Rosenbrock function, but this should not be surprising given the current TRSPs being solved. 

The `sum_squared` hfun was originally added as an hFun to compare GOOMBAH against Pounders. 