### PR TITLE
Fixing indexing error in MSP

### DIFF
--- a/manifold_sampling/py/update_models.py
+++ b/manifold_sampling/py/update_models.py
@@ -19,7 +19,7 @@ def update_models(hfun, Ffun, n, p, nf, nf_max, xkin, delta, F, X, h, Hres, fq_p
     if mp < n and geometry_pt_flag:  # Must obtain and evaluate bounded geometry points
         Mdir, mp = bmpts(X[xkin], Mdir[: n - mp], L, U, delta, fq_pars["Par"][2])
 
-        for i in range(min(n - mp, nf_max - nf)):
+        for i in range(min(n - mp, nf_max - nf - 1)):
             nf, X, F, h, Hash, _ = call_user_scripts(nf, X, F, h, Hash, Ffun, hfun, X[xkin, :] + Mdir[i, :], tol, L, U, 1)
             D = Mdir[i, :]
 


### PR DESCRIPTION
Because `nf` in python is the index of the last-evaluated point, it is one less than the number of evaluated points.

We can evaluate at most `nfmax - nf - 1` when updating models.

This was into `develop` in #139 
