### PR TITLE
Fewer MATLAB tests

### DIFF
--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -15,10 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
-        matlab-release: ["R2022a", "R2022b",
-                         "R2023a", "R2023b",
-                         "R2024a", "R2024b",
-                         "R2025a"]
+        matlab-release: ["R2021a", "latest"]
         exclude:
           # Failing with a possible issue outside IBCDFO (Issue #157)
           - os: macos-14


### PR DESCRIPTION
PR self-review

- [x] Careful review of these extensive changes
   * Confirmed that R2021a is the [oldest available version](https://github.com/matlab-actions/setup-matlab?tab=readme-ov-file#set-up-matlab) in the MATLAB setup action
- [x] Review R2021a and latest action logs
   * `latest` is using R2025a as expected
- [x] Confirm that all actions passing
   * MATLAB test action ran just a bit faster than Python test action, which was not intended but seems nice.