### PR TITLE
Speeding up model updates

### DIFF
--- a/manifold_sampling/py/update_models.py
+++ b/manifold_sampling/py/update_models.py
@@ -8,10 +8,10 @@ def update_models(hfun, Ffun, n, p, nf, nf_max, xkin, delta, F, X, h, Hres, fq_p
     Cres = F[xkin, :]
     Res = np.zeros(F.shape)  # Stores the residuals for model updates
 
-    for i in range(nf):
-        D = X[i] - X[xkin]
-        for j in range(len(Cres)):
-            Res[i, j] = (F[i, j] - Cres[j]) - 0.5 * np.dot(D, np.dot(Hres[:, :, j], D.T))
+    D = np.zeros((nf + 1, X.shape[1]))
+    D[:, :] = X[: nf + 1, :] - X[xkin]
+    for i, Di in enumerate(D):
+        Res[i, :] = (F[i, :] - Cres[:]) - 0.5 * np.einsum("i,ijk,j->k", Di, Hres, Di)
 
     Mdir, mp, valid, Gres, Hresdel, _ = formquad(X[: nf + 1, :], Res[: nf + 1, :], delta, xkin, fq_pars["npmax"], fq_pars["Par"], 0)
 
@@ -21,10 +21,8 @@ def update_models(hfun, Ffun, n, p, nf, nf_max, xkin, delta, F, X, h, Hres, fq_p
 
         for i in range(min(n - mp, nf_max - nf - 1)):
             nf, X, F, h, Hash, _ = call_user_scripts(nf, X, F, h, Hash, Ffun, hfun, X[xkin, :] + Mdir[i, :], tol, L, U, 1)
-            D = Mdir[i, :]
-
-            for j in range(p):
-                Res[nf, j] = (F[nf, j] - Cres[j]) - 0.5 * np.dot(D, np.dot(Hres[:, :, j], D.T))
+            Di = Mdir[i, :]
+            Res[nf, :] = (F[nf, :] - Cres[:]) - 0.5 * np.einsum("i,ijk,j->k", Di, Hres, Di)
 
         _, _, valid, Gres, Hresdel, _ = formquad(X[: nf + 1], Res[: nf + 1], delta, xkin, fq_pars["npmax"], fq_pars["Par"], 0)
 


### PR DESCRIPTION
This mirrors https://github.com/POptUS/IBCDFO/pull/141 to use `einsum` to accelerate `update_models.py`