### PR TITLE
A starting concurrent pounders version

### DIFF
--- a/pounders/py/concurrent_pounders.py
+++ b/pounders/py/concurrent_pounders.py
@@ -36,6 +36,11 @@ def _default_prior():
 
 def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Options=None, Model=None):
     """
+    This modification of pounders takes all model_building points and sends
+    them to the Ffun as a batch. The Ffun can then send them to be evaluated
+    concurrently, giving significant wall-time speed up to many problems,
+    especially for Ffun objectives with larger input dimensions.
+
     POUNDERS: Practical Optimization Using No Derivatives for sums of Squares
       [X, F, hF, flag, xk_in] = pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp)
 
@@ -198,13 +203,14 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         [Mdir, mp, valid, Gres, Hresdel, Mind] = formquad(X[0 : nf + 1, :], Res[0 : nf + 1, :], delta, xk_in, Model["np_max"], Model["Par"], 0)
         if mp < n:
             [Mdir, mp] = bmpts(X[xk_in], Mdir[0 : n - mp, :], Low, Upp, delta, Model["Par"][2])
-            for i in range(int(min(n - mp, nf_max - (nf + 1)))):
+            k_new = int(min(n - mp, nf_max - (nf + 1)))  # new geometry points to send to Ffun (while respecting nfmax)
+            idx_new = nf + 1 + np.arange(k_new)  # absolute indices of these points 
+
+            X[idx_new] = np.minimum(Upp, np.maximum(Low, X[xk_in] + Mdir[:k_new, :]))
+            F[idx_new] = Ffun(X[idx_new])
+
+            for i in range(k_new):
                 nf += 1
-                X[nf] = np.minimum(Upp, np.maximum(Low, X[xk_in] + Mdir[i, :]))
-                F[nf] = Ffun(X[nf])
-                if np.any(np.isnan(F[nf])):
-                    X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -3)
-                    return X, F, hF, flag, xk_in
                 hF[nf] = hfun(F[nf])
                 if printf:
                     print("%4i   Geometry point  %11.5e\n" % (nf, hF[nf]))

--- a/pounders/py/tests/test_pounders_par_model_building.py
+++ b/pounders/py/tests/test_pounders_par_model_building.py
@@ -1,0 +1,52 @@
+import numpy as np
+from ibcdfo.pounders import general_h_funs, concurrent_pounders
+
+
+def call_beamline_simulation_batch(X):
+    # In here, put your call to your simulation that takes in the parameters 
+    # x in rows of X and returns the three values used in the calculation of
+    # emittance.
+    # out = put_your_sim_call_here(x)
+    print(X.shape)
+
+    X = np.atleast_2d(X) # Just to make life easier
+
+    out = np.zeros((X.shape[0],3)) # We will always have a (rows-in-X by 3) output
+    for i, x in enumerate(X): 
+        out[i] = x[:3]  # This is not doing any beamline simulation!
+    return np.squeeze(out)
+
+
+np.random.seed(8675309)
+# Adjust these:
+n = 4  # Number of parameters to be optimized
+X_0 = np.random.uniform(0, 1, (1, n))  # starting parameters for the optimizer
+nf_max = int(100)  # Max number of evaluations to be used by optimizer
+Low = -1 * np.ones((1, n))  # 1-by-n Vector of lower bounds
+Upp = np.ones((1, n))  # 1-by-n Vector of upper bounds
+printf = True
+
+# Not as important to adjust:
+hfun = general_h_funs.emittance_h
+combinemodels = general_h_funs.emittance_combine
+m = 3  # The number of outputs from the beamline simulation. Should be 3 for emittance minimization
+g_tol = 1e-8  # Stopping tolerance
+delta_0 = 0.1  # Initial trust-region radius
+F_0 = np.zeros((1, m))  # Initial evaluations (parameters with completed simulations)
+F_0[0] = call_beamline_simulation(X_0)
+nfs = 1  # Number of initial evaluations
+xk_in = 0  # Index in F_0 for starting the optimization (usually the point with minimal emittance)
+
+Options = {}
+Options["printf"] = printf
+Options["hfun"] = hfun
+Options["combinemodels"] = combinemodels
+
+Prior = {"X_init": X_0, "F_init": F_0, "nfs": nfs, "xk_in": xk_in}
+
+# The call to the method
+[Xout, Fout, hFout, flag, xk_inout] = concurrent_pounders.pounders(call_beamline_simulation_batch, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=Prior, Options=Options, Model={})
+
+assert flag >= 0, "pounders crashed"
+
+assert hFout[xk_inout] == np.min(hFout), "The minimum emittance is not at xk_inout"


### PR DESCRIPTION
This version of pounders differs very slightly from the default.

Default `pounders.py` sequentially processes the directions `Mdir` for model building produced by `formquad`.
This version sends all of the corresponding points in a group to `Ffun`. 
`Ffun` could evaluate them sequentially, or use concurrent resources. 

When the dimension `n` is large and there are sufficient computational resources to evaluate `Ffun` concurrently, there are considerable possible wallclock savings by evaluating model building points concurrently. 

To work, `Ffun` must return evaluations in the same order they were given. Therefore, there is no difference in the sequence of points generated by these versions of `pounders.py` and `concurrent_pounders.py` . 

See:
````
diff concurrent_pounders.py pounders.py
diff test_pounders_par_model_building.py test_emittance_opt.py 
````
to best see the changes in this PR. 

