### PR TITLE
Update GH action runner usage

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,11 +21,11 @@ jobs:
     ##-- General Setup Steps
     # Submodule contents are not used to build User or Developer Guides
     - name: Checkout IBCDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.14
     - name: Setup Python with tox
@@ -46,7 +46,7 @@ jobs:
         tox -r -e html
 
     - name: Archive IBCDFO docs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ibcdfo-sphinx-docs
         path: |

--- a/.github/workflows/check_matlab_standards.yml
+++ b/.github/workflows/check_matlab_standards.yml
@@ -17,11 +17,11 @@ jobs:
       # -- General Setup Steps
       # No need to check standards in submodules
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies

--- a/.github/workflows/check_python_standards.yml
+++ b/.github/workflows/check_python_standards.yml
@@ -16,11 +16,11 @@ jobs:
       # -- General Setup Steps
       # No need to check standards in submodules
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Setup Python with tox

--- a/.github/workflows/check_spelling.yml
+++ b/.github/workflows/check_spelling.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout IBCDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
     - name: Spell Check Repo
-      uses: crate-ci/typos@v1.38.1
+      uses: crate-ci/typos@v1.44.0
       with:
         config: ${{ env.TYPOS_CFG }}

--- a/.github/workflows/measure_coverage.yml
+++ b/.github/workflows/measure_coverage.yml
@@ -31,16 +31,16 @@ jobs:
       # -- General Setup Steps
       # This action requires minq
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout BenDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: POptUS/BenDFO
           path: BenDFO
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Setup Python with tox
@@ -61,7 +61,7 @@ jobs:
 
       # -- Publish as artifact for users and subsequent jobs
       - name: Archive Python coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-coverage-results
           path: |
@@ -76,11 +76,11 @@ jobs:
     steps:
       # -- General Setup Steps
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout BenDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: POptUS/BenDFO
           path: BenDFO
@@ -112,7 +112,7 @@ jobs:
 
       # -- Publish as artifact for users and subsequent jobs
       - name: Archive MATLAB coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: matlab-coverage-results
           path: |
@@ -127,24 +127,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
 
       - name: Access Python coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-coverage-results
           path: ${{ env.CLONE_PATH }}
 
       - name: Access MATLAB coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: matlab-coverage-results
           path: ${{ env.CLONE_PATH }}
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ on:
   #
   # Significant but simpler testing is done on feature branches using the
   # test_python action.
+  # TODO: Remove the following after this has been tested in this branch.
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
   release:
@@ -81,9 +84,9 @@ jobs:
         # python-versions must be maintained consistent with associated
         # pyproject.toml and tox.ini configuration.
         #
-        # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
-        # This means that this action is **not** running any mac tests using
-        # Intel chips.
+        # TODO: Strange failures on macos-15-intel and macos-26-intel prevent
+        # its use (Issue 235).  This means that this action is **not** running
+        # any mac tests using Intel chips.
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
@@ -128,9 +131,9 @@ jobs:
         # python-versions must be maintained consistent with associated
         # pyproject.toml and tox.ini configuration.
         #
-        # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
-        # This means that this action is **not** running any mac tests using
-        # Intel chips.
+        # TODO: Strange failures on macos-15-intel and macos-26-intel prevent
+        # its use (Issue 235).  This means that this action is **not** running
+        # any mac tests using Intel chips.
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
       #
       # Submodule content is not needed to build distributions.
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Construct sdist and wheel
@@ -66,7 +66,7 @@ jobs:
           python -m build
           popd
       - name: Archive both distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ibcdfo-release-candidate
           path: |
@@ -84,27 +84,27 @@ jobs:
         # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
         # This means that this action is **not** running any mac tests using
         # Intel chips.
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       # Install MINQ at commit specified in current submodule setting rather
       # than installing as clone of actual MINQ repo.
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout BenDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: POptUS/BenDFO
           path: BenDFO
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Obtain release candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ibcdfo-release-candidate
           path: ${{ env.CLONE_PATH }}
@@ -131,27 +131,27 @@ jobs:
         # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
         # This means that this action is **not** running any mac tests using
         # Intel chips.
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       # Install MINQ at commit specified in current submodule setting rather
       # than installing as clone of actual MINQ repo.
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout BenDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: POptUS/BenDFO
           path: BenDFO
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Obtain release candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ibcdfo-release-candidate
           path: ${{ env.CLONE_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,6 @@ on:
   #
   # Significant but simpler testing is done on feature branches using the
   # test_python action.
-  # TODO: Remove the following after this has been tested in this branch.
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
   release:
@@ -85,7 +82,7 @@ jobs:
         # pyproject.toml and tox.ini configuration.
         #
         # TODO: Strange failures on macos-15-intel and macos-26-intel prevent
-        # its use (Issue 235).  This means that this action is **not** running
+        # their use (Issue 235).  This means that this action is **not** running
         # any mac tests using Intel chips.
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -132,7 +129,7 @@ jobs:
         # pyproject.toml and tox.ini configuration.
         #
         # TODO: Strange failures on macos-15-intel and macos-26-intel prevent
-        # its use (Issue 235).  This means that this action is **not** running
+        # their use (Issue 235).  This means that this action is **not** running
         # any mac tests using Intel chips.
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -17,7 +17,7 @@ jobs:
   test_ibcdfo:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-15-intel]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26, macos-26-intel]
         matlab-release: ["R2021a", "latest"]
         exclude:
           # Failing with a possible issue outside IBCDFO (Issue #157)
@@ -27,12 +27,12 @@ jobs:
     steps:
     # -- General Setup Steps
     - name: Checkout IBCDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: IBCDFO
         submodules: recursive
     - name: Checkout BenDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: POptUS/BenDFO
         path: BenDFO

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -24,23 +24,24 @@ jobs:
       # This means that this action is **not** running any mac tests using Intel
       # chips.
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
+        #os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
+        os: [macos-26-intel]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
     # -- General Setup Steps
     # This action requires minq
     - name: Checkout IBCDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Checkout BenDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: POptUS/BenDFO
         path: BenDFO
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Python with tox

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -20,12 +20,12 @@ jobs:
       # python-versions must be maintained consistent with associated
       # pyproject.toml and tox.ini configuration.
       #
-      # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
-      # This means that this action is **not** running any mac tests using Intel
-      # chips.
+      # TODO: Strange failures on macos-15-intel and macos-26-intel prevent its
+      # use (Issue 235).  This means that this action is **not** running any mac
+      # tests using Intel chips.
       matrix:
         #os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
-        os: [macos-26-intel]
+        os: [macos-14-large]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -24,7 +24,7 @@ jobs:
       # This means that this action is **not** running any mac tests using Intel
       # chips.
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -24,8 +24,7 @@ jobs:
       # use (Issue 235).  This means that this action is **not** running any mac
       # tests using Intel chips.
       matrix:
-        #os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
-        os: [macos-14-large]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_python_oldest.yml
+++ b/.github/workflows/test_python_oldest.yml
@@ -20,21 +20,21 @@ jobs:
       # This means that this action is **not** running any mac tests using Intel
       # chips.
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
     # This action requires minq
     - name: Checkout IBCDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Checkout BenDFO repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: POptUS/BenDFO
         path: BenDFO
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Setup Python with tox

--- a/.github/workflows/test_python_oldest.yml
+++ b/.github/workflows/test_python_oldest.yml
@@ -16,9 +16,9 @@ jobs:
       # python-versions must be maintained consistent with associated
       # pyproject.toml and tox.ini configuration.
       #
-      # TODO: Strange failures on macos-15-intel prevent its use (Issue 235).
-      # This means that this action is **not** running any mac tests using Intel
-      # chips.
+      # TODO: Strange failures on macos-15-intel and macos-26-intel prevent its
+      # use (Issue 235).  This means that this action is **not** running any mac
+      # tests using Intel chips.
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -20,16 +20,16 @@ jobs:
       # -- General Setup Steps
       # This action requires minq
       - name: Checkout IBCDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout BenDFO repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: POptUS/BenDFO
           path: BenDFO
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Setup Python with tox

--- a/pounders/m/tests/test_one_m_pounders.m
+++ b/pounders/m/tests/test_one_m_pounders.m
@@ -1,6 +1,6 @@
 % This tests the ability of the MATLAB pounders to solve a one-residual
 % problem. The benefit of pounders comes from its handling of the separate
-% residuals, and combinging them using the known form of an outer function.
+% residuals, and combining them using the known form of an outer function.
 % So this is not how pounders is intended to be used, but can be a comparison
 % method.
 


### PR DESCRIPTION
Pending Tasks

- [x] After confirming that the `release` GH action runs as expected and successfully with the updates made here, alter it so that it no longer runs on pull requests

PR Self-review

- [x] Carefully review all changes made here
- [x] Confirm that the Node.js 20 deprecation warnings are no longer present (where possible)
  * The MATLAB actions result in this warning.  These will have to be addressed once Mathworks provides newer versions of these actions.
- [x] Confirm that the correct set of test setups is run for all actions whose test setups were altered
- [x] Confirm that all actions that create artifacts are still creating artifacts and that these are good
- [x] Spot check logs of altered actions to ensure that all is good after the modernization
- [x] Confirm all actions passing