### PR TITLE
Clean up distribution for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ composite derivative-free optimization problems.
 
 All code included in IBCDFO is open source, with the specific license for each component provided in the corresponding top-level
 subdirectory. If a subdirectory does not contain a LICENSE file, it is covered by the
-IBCDFO [LICENSE](/LICENSE).
+IBCDFO [LICENSE](https://github.com/poptus/IBCDFO/blob/main/LICENSE).
 
 Copyright (c) 2023-2026, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory and UChicago Argonne


### PR DESCRIPTION
PR Self-review

- [x] Review all changes made here
- [x] Confirm that new link is correct and functions
- [x] Confirm all actions passing

I see in the test PyPI rendering of the package's information that only Jeff appears as an author.  I have confirmed that the full author list is present and correct in the metadata of the distributions.  A [PyPI issue](https://github.com/pypi/warehouse/issues/12877) indicates that this is a known issue with no fix at present.

In addition, the PyPI rendering contains badges that might provide incorrect information to users.  I have created Issue #288 as a post release task to address this potential issue as part of a larger task.