### PR TITLE
Store flag and best incumbent index

### DIFF
--- a/pounders/py/tests/TestPoundersExtensive.py
+++ b/pounders/py/tests/TestPoundersExtensive.py
@@ -127,6 +127,8 @@ class TestPounders(unittest.TestCase):
                 Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["Fvec"] = F
                 Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["H"] = hF
                 Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["X"] = X
+                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["flag"] = flag
+                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["xk_best"] = xk_best
                 # oct2py.kill_octave() # This is necessary to restart the octave instance,
                 #                      # and thereby remove some caching of inside of oct2py,
                 #                      # namely changing problem dimension does not

--- a/pounders/py/tests/compare_results.py
+++ b/pounders/py/tests/compare_results.py
@@ -44,7 +44,7 @@ def _load_results_py_v1(filename):
 
 def _load_results_py_v2(filename):
     """
-    POUNDERS/Python v2 format established at commit XXX
+    POUNDERS/Python v2 format established at commit 9f5a5f37c
     """
     EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
 

--- a/pounders/py/tests/compare_results.py
+++ b/pounders/py/tests/compare_results.py
@@ -42,6 +42,51 @@ def _load_results_py_v1(filename):
     return algorithm, problem, X, Fvec, H
 
 
+def _load_results_py_v2(filename):
+    """
+    POUNDERS/Python v2 format established at commit XXX
+    """
+    EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
+
+    contents = scipy.io.loadmat(filename)
+    keys = [k for k in contents.keys() if not k.startswith("__")]
+    assert len(keys) == 1
+    assert keys[0].startswith("pounders4py_")
+    data = contents[keys[0]]
+    assert set(data.dtype.names) == EXPECTED_KEYS
+
+    algorithm = data["alg"][0][0][0]
+    problem = data["problem"][0][0][0]
+
+    H = np.squeeze(data["H"][0][0])
+    assert H.ndim == 1
+    n_evaluations = len(H)
+    assert all(np.isreal(H))
+    assert all(np.isfinite(H))
+
+    Fvec = np.squeeze(data["Fvec"][0][0])
+    assert Fvec.ndim == 2
+    tmp, _ = Fvec.shape
+    assert tmp == n_evaluations
+    assert all(np.isreal(Fvec.flatten()))
+    assert all(np.isfinite(Fvec.flatten()))
+
+    X = np.squeeze(data["X"][0][0])
+    assert X.ndim == 2
+    tmp, _ = X.shape
+    assert tmp == n_evaluations
+    assert all(np.isreal(X.flatten()))
+    assert all(np.isfinite(X.flatten()))
+
+    flag = np.squeeze(data["flag"][0][0])
+    assert np.isreal(flag)
+    assert np.isfinite(flag)
+    xk_best = np.squeeze(data["xk_best"][0][0])
+    assert xk_best in range(0, len(H))
+
+    return algorithm, problem, X, Fvec, H, xk_best, flag
+
+
 def _load_results_m_v1(filename):
     """
     POUNDERS/MATLAB v1 format established at commit 360d6e29
@@ -82,7 +127,7 @@ def compare_results(filename_benchmark, filename_result):
         return False
 
     ref_alg, ref_problem, X_ref, F_ref, H_ref = _load_results_py_v1(filename_benchmark)
-    new_alg, new_problem, X_new, F_new, H_new = _load_results_py_v1(filename_result)
+    new_alg, new_problem, X_new, F_new, H_new, x_best_new, flag_new = _load_results_py_v2(filename_result)
 
     if ref_alg not in ["pounders4py"]:
         error(f"Invalid algorithm name ({ref_alg}) for benchmark")


### PR DESCRIPTION
Concentrating on advancing from v1 benchmark results to v2 **with Python only**.

PR Self-review

- [x] Review all changes here
- [x] Acquire two different sets of v2 Python benchmarks via clean `tox` `nocoverage` task @ commit 9f5a5f37
    * `benchmarks_py_v2` and `gce_c01_py_v2`
    * Used script to confirm deterministic execution of benchmarks acquisition on each system
- [x] Confirm that comparing Python results obtained at 9f5a5f37c with different setups results in script identifying mismatches with expected output (including exit codes)
- [x] Confirm that Python results at the final commit on this branch are identical to v1 benchmarks
- [x] Confirm all actions passing
