### PR TITLE
Establish final version (v3) of Python/POUNDERS benchmarks

### DIFF
--- a/pounders/py/tests/TestPoundersExtensive.py
+++ b/pounders/py/tests/TestPoundersExtensive.py
@@ -121,14 +121,11 @@ class TestPounders(unittest.TestCase):
                 elif flag != -6 and flag != -4:
                     self.assertTrue(evals == nf_max + nfs, f"POUNDERs didn't use nf_max evaluations: evals={evals}, expected={nf_max + nfs}, flag={flag}")
 
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)] = {}
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["alg"] = "pounders4py"
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["problem"] = "problem " + str(row) + " from More/Wild"
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["Fvec"] = F
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["H"] = hF
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["X"] = X
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["flag"] = flag
-                Results["pounders4py_" + str(row) + "_" + str(hfun_cases)]["xk_best"] = xk_best
+                # Write results to .mat file using the same format as used by
+                # the MATLAB implementation.  We prefer the .mat format since
+                # Python can write that format as well.  This includes using the
+                # same filenaming scheme.
+                Results = {"alg": "POUNDERS_Py", "problem": "problem " + str(row) + " from More/Wild", "Fvec": F, "H": hF, "X": X, "flag": flag, "xk_best": xk_best}
                 # oct2py.kill_octave() # This is necessary to restart the octave instance,
                 #                      # and thereby remove some caching of inside of oct2py,
                 #                      # namely changing problem dimension does not

--- a/pounders/py/tests/__init__.py
+++ b/pounders/py/tests/__init__.py
@@ -1,1 +1,2 @@
 from .compare_results import compare_results
+from .load_results import load_results

--- a/pounders/py/tests/compare_results.py
+++ b/pounders/py/tests/compare_results.py
@@ -99,6 +99,8 @@ def compare_results(filename_benchmark, filename_result):
         msg = "Benchmark and new result used different algorithms ({} != {})"
         error(msg.format(ref_alg, new_alg))
         return False
+    # TODO: Remove above elif and uncomment this once we check v3 against v3,
+    # which uses POUNDERS_py.
     # elif new_alg != ref_alg:
     #     msg = "Benchmark and new result used different algorithms ({} != {})"
     #     error(msg.format(ref_alg, new_alg))
@@ -128,7 +130,7 @@ def compare_results(filename_benchmark, filename_result):
     # users with all such differences in one go.
     msgs = []
     if x_best_new != x_best_ref:
-        msgs += [f"Best solution indices differ ({x_best_new} != {x_best_ref})"]
+        msgs += [f"Best approximation indices differ ({x_best_new} != {x_best_ref})"]
     if flag_new != flag_ref:
         msgs += [f"Flags differ ({flag_new} != {flag_ref})"]
     if (flag_new >= 0) and (flag_ref >= 0):

--- a/pounders/py/tests/compare_results.py
+++ b/pounders/py/tests/compare_results.py
@@ -2,44 +2,7 @@ import scipy.io
 
 import numpy as np
 
-
-def _load_results_py_v1(filename):
-    """
-    POUNDERS/Python v1 format established at commit 1e5bc98f
-    """
-    EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X"}
-
-    contents = scipy.io.loadmat(filename)
-    keys = [k for k in contents.keys() if not k.startswith("__")]
-    assert len(keys) == 1
-    assert keys[0].startswith("pounders4py_")
-    data = contents[keys[0]]
-    assert set(data.dtype.names) == EXPECTED_KEYS
-
-    algorithm = data["alg"][0][0][0]
-    problem = data["problem"][0][0][0]
-
-    H = np.squeeze(data["H"][0][0])
-    assert H.ndim == 1
-    n_evaluations = len(H)
-    assert all(np.isreal(H))
-    assert all(np.isfinite(H))
-
-    Fvec = np.squeeze(data["Fvec"][0][0])
-    assert Fvec.ndim == 2
-    tmp, _ = Fvec.shape
-    assert tmp == n_evaluations
-    assert all(np.isreal(Fvec.flatten()))
-    assert all(np.isfinite(Fvec.flatten()))
-
-    X = np.squeeze(data["X"][0][0])
-    assert X.ndim == 2
-    tmp, _ = X.shape
-    assert tmp == n_evaluations
-    assert all(np.isreal(X.flatten()))
-    assert all(np.isfinite(X.flatten()))
-
-    return algorithm, problem, X, Fvec, H
+from .load_results import load_results
 
 
 def _load_results_py_v2(filename):
@@ -126,16 +89,20 @@ def compare_results(filename_benchmark, filename_result):
         error(f"New result has different filename ({filename_result.stem})")
         return False
 
-    ref_alg, ref_problem, X_ref, F_ref, H_ref = _load_results_py_v1(filename_benchmark)
-    new_alg, new_problem, X_new, F_new, H_new, x_best_new, flag_new = _load_results_py_v2(filename_result)
+    ref_alg, ref_problem, X_ref, F_ref, H_ref, x_best_ref, flag_ref = _load_results_py_v2(filename_benchmark)
+    new_alg, new_problem, X_new, F_new, H_new, x_best_new, flag_new = load_results(filename_result)
 
     if ref_alg not in ["pounders4py"]:
         error(f"Invalid algorithm name ({ref_alg}) for benchmark")
         return False
-    elif new_alg != ref_alg:
+    elif new_alg != "POUNDERS_Py":
         msg = "Benchmark and new result used different algorithms ({} != {})"
         error(msg.format(ref_alg, new_alg))
         return False
+    # elif new_alg != ref_alg:
+    #     msg = "Benchmark and new result used different algorithms ({} != {})"
+    #     error(msg.format(ref_alg, new_alg))
+    #     return False
 
     if (not ref_problem.startswith("problem")) or (not ref_problem.endswith("from More/Wild")):
         error(f"Invalid problem spec ({ref_problem}) for benchmark")
@@ -160,15 +127,31 @@ def compare_results(filename_benchmark, filename_result):
     # Don't fail immediately if values are different so that we can provide
     # users with all such differences in one go.
     msgs = []
-    if any(H_new != H_ref):
-        max_abs_diff = np.max(np.fabs(H_new - H_ref))
-        msgs += [f"H absolute differences as large as {max_abs_diff}"]
-    if any(F_new.flatten() != F_ref.flatten()):
-        max_abs_diff = np.max(np.fabs(F_new.flatten() - F_ref.flatten()))
-        msgs += [f"Fvec absolute differences as large as {max_abs_diff}"]
-    if any(X_new.flatten() != X_ref.flatten()):
-        max_abs_diff = np.max(np.fabs(X_new.flatten() - X_ref.flatten()))
-        msgs += [f"X absolute differences as large as {max_abs_diff}"]
+    if x_best_new != x_best_ref:
+        msgs += [f"Best solution indices differ ({x_best_new} != {x_best_ref})"]
+    if flag_new != flag_ref:
+        msgs += [f"Flags differ ({flag_new} != {flag_ref})"]
+    if (flag_new >= 0) and (flag_ref >= 0):
+        # Only show comparison if both ran without a hard failure.  For
+        # instance, I would like to see the these comparisons if one or both
+        # were simply nonconvergent.
+        X_best_ref = X_ref[x_best_ref]
+        F_best_ref = F_ref[x_best_ref]
+        H_best_ref = H_ref[x_best_ref]
+
+        X_best_new = X_new[x_best_new]
+        F_best_new = F_new[x_best_new]
+        H_best_new = H_new[x_best_new]
+
+        if H_best_new != H_best_ref:
+            abs_diff = np.fabs(H_best_new - H_best_ref)
+            msgs += [f"H absolute difference = {abs_diff}"]
+        if any(F_best_new != F_best_ref):
+            max_abs_diff = np.max(np.fabs(F_best_new - F_best_ref))
+            msgs += [f"Fvec max absolute difference = {max_abs_diff}"]
+        if any(X_best_new != X_best_ref):
+            max_abs_diff = np.max(np.fabs(X_best_new - X_best_ref))
+            msgs += [f"X max absolute difference = {max_abs_diff}"]
 
     if msgs:
         error("\n\t".join(msgs))

--- a/pounders/py/tests/load_results.py
+++ b/pounders/py/tests/load_results.py
@@ -1,0 +1,47 @@
+import scipy.io
+
+import numpy as np
+
+
+def load_results(filename):
+    """
+    POUNDERS/Python v3 format established at commit XXX
+    """
+    EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
+
+    data = scipy.io.loadmat(filename)
+    keys = [k for k in data.keys() if not k.startswith("__")]
+    assert set(keys) == EXPECTED_KEYS
+
+    algorithm = np.squeeze(data["alg"])
+    problem = np.squeeze(data["problem"])
+
+    H = np.squeeze(data["H"])
+    assert H.ndim == 1
+    n_evaluations = len(H)
+    assert all(np.isreal(H))
+    assert all(np.isfinite(H))
+
+    # Fvec could be a scalar at each evaluation
+    Fvec = np.atleast_2d(np.squeeze(data["Fvec"]))
+    assert Fvec.ndim == 2
+    tmp, _ = Fvec.shape
+    assert tmp == n_evaluations
+    assert all(np.isreal(Fvec.flatten()))
+    assert all(np.isfinite(Fvec.flatten()))
+
+    # X could be a scalar at each evaluation
+    X = np.atleast_2d(np.squeeze(data["X"]))
+    assert X.ndim == 2
+    tmp, _ = X.shape
+    assert tmp == n_evaluations
+    assert all(np.isreal(X.flatten()))
+    assert all(np.isfinite(X.flatten()))
+
+    flag = np.squeeze(data["flag"])
+    assert np.isreal(flag)
+    assert np.isfinite(flag)
+    xk_best = np.squeeze(data["xk_best"])
+    assert xk_best in range(0, len(H))
+
+    return algorithm, problem, X, Fvec, H, xk_best, flag

--- a/pounders/py/tests/load_results.py
+++ b/pounders/py/tests/load_results.py
@@ -5,7 +5,9 @@ import numpy as np
 
 def load_results(filename):
     """
-    POUNDERS/Python v3 format established at commit XXX
+    Based on benchmark results' file format established at commit
+    * fb33cdfd for POUNDERS/Python and
+    * PENDING for POUNDERS/MATLAB.
     """
     EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
 

--- a/tools/compare_pounders_results.py
+++ b/tools/compare_pounders_results.py
@@ -36,12 +36,16 @@ def main():
     print()
     print("POUNDERS Regression Testing")
     print("-" * 80)
-    print(f"Benchmarks\t{ref_path.joinpath("*.mat")}")
-    print(f"New Results\t{new_path.joinpath("*.mat")}")
+    print(f"Benchmarks\t{ref_path.joinpath('*.mat')}")
+    print(f"New Results\t{new_path.joinpath('*.mat')}")
     print()
 
     # ----- IDENTIFY ALL NEW RESULTS
     new_results = [fname.name for fname in new_path.glob("*.mat")]
+    if not new_results:
+        print(f"{RED}ERROR{NC} - No new results found\n")
+        print(f"{RED}FAILURE{NC}\n")
+        return FAILURE
 
     # ----- COMPARE NEW RESULTS AGAINST BENCHMARKS
     # Allow for the benchmarks folder to contain results that we don't have new

--- a/tools/compare_pounders_results.py
+++ b/tools/compare_pounders_results.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
-
+import sys
 from pathlib import Path
 
 from ibcdfo.pounders.tests import compare_results


### PR DESCRIPTION
Concentrating on advancing from v2 benchmark results to final version (v3) **with Python only**.

PR Self-review

- [x] Review all changes here
- [x] Acquire two different sets of v3 Python benchmarks via clean `tox` `nocoverage` task @ commit fb33cdfd
    * `benchmarks_py_v3` and `gce_c01_py_v3`
    * Used script to confirm deterministic execution of benchmarks acquisition on each system
- [x] Confirm that comparing Python results obtained at fb33cdfd with different setups results in script identifying mismatches with expected output (including exit codes)
- [x] Confirm that Python results at the final commit on this branch are identical to v2 benchmarks
- [x] Confirm all actions passing