### PR TITLE
Establish MATLAB v3 Benchmark Format

### DIFF
--- a/pounders/m/tests/benchmark_pounders.m
+++ b/pounders/m/tests/benchmark_pounders.m
@@ -68,7 +68,6 @@ for row = 1:length(dfo)
     end
 
     for hfun_cases = 1:3
-        Results = cell(3, 53);
         if hfun_cases == 1
             hfun = @h_leastsquares;
             combinemodels = @combine_leastsquares;
@@ -121,16 +120,19 @@ for row = 1:length(dfo)
             assert(size(X, 1) == nf_max + nfs, "POUNDERs didn't use nf_max evaluations");
         end
 
-        Results{hfun_cases, row}.alg = 'POUNDERs';
-        Results{hfun_cases, row}.problem = ['problem ' num2str(row) ' from More/Wild'];
-        Results{hfun_cases, row}.Fvec = F;
-        Results{hfun_cases, row}.H = hF;
-        Results{hfun_cases, row}.X = X;
-        Results{hfun_cases, row}.xk_best = xk_best;
-        Results{hfun_cases, row}.flag = flag;
-        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-        %     save('-mat7-binary', filename, 'Results') % Octave save
-        save(filename, 'Results');
+        % Save results to .mat file with identical format to benchmark results
+        % generated with Python implementation.  This includes writing results
+        % with an identical filenaming scheme.
+        %
+        % We have algorithm names specify the language of the implementations
+        % because, for instance, the MATLAB results store the best
+        % approximation index as 1-based as opposed to 0-based as the Python
+        % tests do.
+        alg = 'POUNDERS_M';
+        problem = ['problem ' num2str(row) ' from More/Wild'];
+        Fvec = F;
+        H = hF;
+        save(filename, 'alg', 'problem', 'Fvec', 'H', 'X', 'flag', 'xk_best');
     end
 end
 if ~ensure_still_solve_problems

--- a/pounders/py/tests/TestPoundersExtensive.py
+++ b/pounders/py/tests/TestPoundersExtensive.py
@@ -125,6 +125,11 @@ class TestPounders(unittest.TestCase):
                 # the MATLAB implementation.  We prefer the .mat format since
                 # Python can write that format as well.  This includes using the
                 # same filenaming scheme.
+                #
+                # We have algorithm names specify the language of the
+                # implementations because, for instance, the MATLAB results
+                # store the best approximation index as 1-based as opposed to
+                # 0-based as this test does.
                 Results = {"alg": "POUNDERS_Py", "problem": "problem " + str(row) + " from More/Wild", "Fvec": F, "H": hF, "X": X, "flag": flag, "xk_best": xk_best}
                 # oct2py.kill_octave() # This is necessary to restart the octave instance,
                 #                      # and thereby remove some caching of inside of oct2py,

--- a/pounders/py/tests/compare_results.py
+++ b/pounders/py/tests/compare_results.py
@@ -2,55 +2,7 @@ import scipy.io
 
 import numpy as np
 
-
-def _load_results_m_v1(filename):
-    """
-    POUNDERS/MATLAB v1 format established at commit 360d6e29
-    """
-    EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X"}
-
-    contents = scipy.io.loadmat(filename)
-    keys = [k for k in contents.keys() if not k.startswith("__")]
-    assert len(keys) == 1
-    assert keys[0] == "Results"
-
-    # Only one valid set of results across all three known hfun cases.
-    data = None
-    tmp = contents[keys[0]]
-    assert len(tmp) == 3
-    for hfun in range(len(tmp)):
-        # See if we can find that one valid result for this hfun case.
-        tmp_i = [e for e in tmp[hfun] if np.squeeze(e).ndim == 0]
-        if tmp_i:
-            assert len(tmp_i) == 1
-            assert data is None
-            data = tmp_i[0][0]
-            assert data is not None
-
-    assert set(data.dtype.names) == EXPECTED_KEYS
-
-    algorithm = data["alg"][0][0]
-    problem = data["problem"][0][0]
-
-    H = np.squeeze(data["H"][0])
-    assert H.ndim == 1
-    n_evaluations = len(H)
-    assert all(np.isreal(H))
-
-    Fvec = np.squeeze(data["Fvec"][0])
-    assert Fvec.ndim == 2
-    tmp, _ = Fvec.shape
-    assert tmp == n_evaluations
-    assert all(np.isreal(Fvec.flatten()))
-
-    X = np.squeeze(data["X"][0])
-    assert X.ndim == 2
-    tmp, _ = X.shape
-    assert tmp == n_evaluations
-    assert all(np.isreal(X.flatten()))
-    assert all(np.isfinite(X.flatten()))
-
-    return algorithm, problem, X, Fvec, H
+from .load_results import load_results
 
 
 def _load_results_m_v2(filename):
@@ -143,7 +95,7 @@ def compare_results(filename_benchmark, filename_result):
         error(f"New result has different filename ({filename_result.stem})")
         return False
 
-    ref_alg, ref_problem, X_ref, F_ref, H_ref = _load_results_m_v1(filename_benchmark)
+    ref_alg, ref_problem, X_ref, F_ref, H_ref, x_best_ref, flag_ref = _load_results_m_v2(filename_benchmark)
     if not all(np.isfinite(H_ref)):
         error("Non-finite h values in benchmark")
         return False
@@ -151,7 +103,7 @@ def compare_results(filename_benchmark, filename_result):
         error("Non-finite Fvec values in benchmark")
         return False
 
-    new_alg, new_problem, X_new, F_new, H_new, x_best_new, flag_new = _load_results_m_v2(filename_result)
+    new_alg, new_problem, X_new, F_new, H_new, x_best_new, flag_new = load_results(filename_result)
     if not all(np.isfinite(H_new)):
         error("Non-finite h values in new results")
         return False
@@ -159,26 +111,17 @@ def compare_results(filename_benchmark, filename_result):
         error("Non-finite Fvec values in new results")
         return False
 
-    # Fake these values until the MATLAB format results have them stored.
-    x_best_ref = x_best_new
-    flag_ref = flag_new
-
+    # TODO: Once we are testing v3 against v3, remove this check since
+    # load_result() error checks the algorithm name and we would like to check
+    # MATLAB results against Python results.
     if ref_alg not in ["POUNDERs"]:
         error(f"Invalid algorithm name ({ref_alg}) for benchmark")
         return False
-    elif new_alg != ref_alg:
+    elif new_alg != "POUNDERS_M":
         msg = "Benchmark and new result used different algorithms ({} != {})"
         error(msg.format(ref_alg, new_alg))
         return False
 
-    if (not ref_problem.startswith("problem")) or (not ref_problem.endswith("from More/Wild")):
-        error(f"Invalid problem spec ({ref_problem}) for benchmark")
-        return False
-    try:
-        int(ref_problem.lstrip("problem").rstrip("from More/Wild"))
-    except Exception:
-        error(f"Invalid problem spec ({ref_problem}) for benchmark")
-        return False
     if new_problem != ref_problem:
         msg = "Benchmark and new result solve different problems ({} != {})"
         error(msg.format(ref_problem, new_problem))

--- a/pounders/py/tests/load_results.py
+++ b/pounders/py/tests/load_results.py
@@ -7,7 +7,7 @@ def load_results(filename):
     """
     Based on benchmark results' file format established at commit
     * fb33cdfd for POUNDERS/Python and
-    * PENDING for POUNDERS/MATLAB.
+    * 2b4d9603 for POUNDERS/MATLAB.
     """
     EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
 

--- a/pounders/py/tests/load_results.py
+++ b/pounders/py/tests/load_results.py
@@ -11,18 +11,31 @@ def load_results(filename):
     """
     EXPECTED_KEYS = {"alg", "problem", "H", "Fvec", "X", "flag", "xk_best"}
 
-    data = scipy.io.loadmat(filename)
+    # When adapting this to loading from MATLAB-generated files on GCE, I was
+    # forced to add the simplify_cells argument.  Without this, some loaded
+    # results had a "W" or a "V" field instead of the "X" field.  When I loaded
+    # those same files manually in Python using the exact same venv and
+    # scipy.io.loadmat(filename), I always saw the "X" field and didn't see the
+    # others.  I don't understand why this was happening nor why the addition
+    # of the flag solves it.
+    data = scipy.io.loadmat(filename, simplify_cells=True)
     keys = [k for k in data.keys() if not k.startswith("__")]
     assert set(keys) == EXPECTED_KEYS
 
     algorithm = str(np.squeeze(data["alg"]))
+
     problem = str(np.squeeze(data["problem"]))
+    if (not problem.startswith("problem")) or (not problem.endswith("from More/Wild")):
+        raise ValueError(f"Invalid problem spec ({problem})")
+    try:
+        int(problem.lstrip("problem").rstrip("from More/Wild"))
+    except Exception:
+        raise ValueError(f"Invalid problem spec ({problem})")
 
     H = np.squeeze(data["H"])
     assert H.ndim == 1
     n_evaluations = len(H)
     assert all(np.isreal(H))
-    assert all(np.isfinite(H))
 
     # Fvec could be a scalar at each evaluation
     Fvec = np.atleast_2d(np.squeeze(data["Fvec"]))
@@ -30,7 +43,6 @@ def load_results(filename):
     tmp, _ = Fvec.shape
     assert tmp == n_evaluations
     assert all(np.isreal(Fvec.flatten()))
-    assert all(np.isfinite(Fvec.flatten()))
 
     # X could be a scalar at each evaluation
     X = np.atleast_2d(np.squeeze(data["X"]))
@@ -44,6 +56,13 @@ def load_results(filename):
     assert np.isreal(flag)
     assert np.isfinite(flag)
     xk_best = np.squeeze(data["xk_best"])
+    if algorithm == "POUNDERS_M":
+        # The MATLAB implementation's test suite saves the index of the best
+        # approximation as a 1-based integer.  However, we need to adjust it to
+        # 0-based since we are returning Python arrays.
+        xk_best -= 1
+    elif algorithm != "POUNDERS_Py":
+        raise ValueError(f"Unknown POUNDERS test algorithm {algorithm}")
     assert xk_best in range(0, len(H))
 
     return algorithm, problem, X, Fvec, H, xk_best, flag


### PR DESCRIPTION
Concentrating on advancing from v2 benchmark results to final version (v3) **with MATLAB only**.

PR Self-review

- [x] Review all changes here
- [x] Acquire two different sets of v3 MATLAB benchmarks manually @ commit 2b4d9603
    * `gce_c01_m_v3` and `gce_c12_m_v3`
- [x] Used script running off of new, clean `nocoverage` venv built at latest commit in branch to confirm deterministic execution of benchmarks acquisition on each system
- [x] Confirm that comparing MATLAB results obtained at 2b4d9603 with different setups results in script identifying mismatches with expected output (including exit codes)
- [x] Confirm that MATLAB results at the final commit on this branch are identical to v2 benchmarks
- [x] Confirm all actions passing