### PR TITLE
Fixing a bug with success

### DIFF
--- a/manifold_sampling/m/manifold_sampling_primal.m
+++ b/manifold_sampling/m/manifold_sampling_primal.m
@@ -89,6 +89,8 @@ H_mm = zeros(n);
 while nf < nf_max && delta > tol.mindelta
     bar_delta = delta;
 
+    successful = false;
+
     % Line 3: manifold sampling while loop
     while nf < nf_max
 
@@ -168,7 +170,6 @@ while nf < nf_max && delta > tol.mindelta
 
                 % Line 20: See if intersection is nonempty
                 if any(ismember(hashes_at_nf, Act_Z_k))
-                    successful = false; % iteration is unsuccessful
                     break
                 else
                     % Line 24: Shrink delta

--- a/manifold_sampling/py/manifold_sampling_primal.py
+++ b/manifold_sampling/py/manifold_sampling_primal.py
@@ -107,6 +107,7 @@ def manifold_sampling_primal(hfun, Ffun, x0, L, U, nf_max, subprob_switch):
 
         bar_delta = delta
 
+        successful = False
         # Line 3: manifold sampling while loop
         while nf + 1 < nf_max:
             # Line 4: build models
@@ -167,7 +168,6 @@ def manifold_sampling_primal(hfun, Ffun, x0, L, U, nf_max, subprob_switch):
                 if np.all(np.isin(tmp_Act_Z_k, Act_Z_k)):
                     # Line 20: See if intersection is nonempty
                     if np.any(np.isin(hashes_at_nf, Act_Z_k)):
-                        successful = False
                         break
                     else:
                         # Line 24: Shrink delta


### PR DESCRIPTION
Fix a bug in the manifold sampling main loop where the `successful` flag could persist from a previous iteration when termination occurred at the budget `nf_max`. Previously, if the algorithm exited the inner loop due to reaching `nf_max`, a stale `successful=True` value could cause the trust-region center (`xkin`) to be updated to the most recent evaluation, even when that point was not accepted as an improving iterate. 

The fix resets `successful` at the start of each outer iteration and removes an unnecessary reassignment inside the failure logic, ensuring that only genuinely successful iterations update the incumbent solution.