### PR TITLE
Add create TRSP solver function

### DIFF
--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -15,28 +15,28 @@ function [solver] = create_trsp_solver(spsolver)
     % ----- DEFINE POUNDERS-COMPATIBLE INTERFACES ON SOLVERS
     % Stefan's crappy 10 line solver
     function [Xsp, mdec, trsp_err] = bqmin_wrapper(H, G, Low, Upp)
+        % Assume that solver error checks its arguments thoroughly and that
+        % solver always finds valid solution.
         trsp_err = 0;
         [Xsp, mdec] = bqmin(H, G, Low, Upp);
     end
 
     % Arnold Neumaier's minq5
     function [Xsp, mdec, trsp_err] = minq5_wrapper(H, G, Low, Upp)
-        trsp_err = 0;
-
+        % Assume that solver error checks its arguments thoroughly.
         xx = zeros(size(H, 1), 1);
-        [Xsp, mdec, minq_err] = minqsw(0, G, H, Low', Upp', 0, xx);
-        if minq_err < 0
-            trsp_err = -4;
-        end
+        [Xsp, mdec, trsp_err] = minqsw(0, G, H, Low', Upp', 0, xx);
         % Continuous function restricted to (compact) k-cell.
-        assert(minq_err ~= 1);
+        assert(trsp_err ~= 1);
         % See comments in Python version of this function for info on handling
         % error code 99.
-        % assert(minq_err ~= 99);
+        % assert(trsp_err ~= 99);
     end
 
     % Arnold Neumaier's minq8
     function [Xsp, mdec, trsp_err] = minq8_wrapper(H, G, Low, Upp)
+        % Assume that solver error checks its arguments thoroughly and that
+        % solver always finds valid solution.
         trsp_err = 0;
 
         n = size(H, 1);

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -52,18 +52,18 @@ function [solver] = create_trsp_solver(spsolver)
 
     % ----- DEFINE POUNDERS-COMPATIBLE INTERFACES ON SOLVERS
     % Stefan's crappy 10 line solver
-    function [Xsp, mdec, found_solution] = bqmin_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = bqmin_wrapper(H, g, Low, Upp)
         % Assume that solver error checks its arguments thoroughly and that
         % solver always finds valid solution.
         found_solution = true;
-        [Xsp, mdec] = bqmin(H, G, Low, Upp);
+        [Xsp, mdec] = bqmin(H, g, Low, Upp);
     end
 
     % Arnold Neumaier's minq5
-    function [Xsp, mdec, found_solution] = minq5_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = minq5_wrapper(H, g, Low, Upp)
         % Assume that solver error checks its arguments thoroughly.
         xx = zeros(size(H, 1), 1);
-        [Xsp, mdec, minq_err] = minqsw(0, G, H, Low', Upp', 0, xx);
+        [Xsp, mdec, minq_err] = minqsw(0, g, H, Low', Upp', 0, xx);
         % Continuous function restricted to (compact) k-cell.
         assert(minq_err ~= 1);
         % See comments in Python version of this function for info on handling
@@ -73,7 +73,7 @@ function [solver] = create_trsp_solver(spsolver)
     end
 
     % Arnold Neumaier's minq8
-    function [Xsp, mdec, found_solution] = minq8_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = minq8_wrapper(H, g, Low, Upp)
         % Assume that solver error checks its arguments thoroughly and that
         % solver always finds valid solution.
         found_solution = true;
@@ -81,7 +81,7 @@ function [solver] = create_trsp_solver(spsolver)
         n = size(H, 1);
 
         data.gam = 0;
-        data.c = G;
+        data.c = g;
         data.b = zeros(n, 1);
         [tmp1, tmp2] = ldl(H);
         data.D = diag(tmp2);

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -102,6 +102,6 @@ function [solver] = create_trsp_solver(spsolver)
         check_minq_installation(8);
         solver = @minq8_wrapper;
     else
-        error('POUNDERS:badValue', sprintf("Invalid TRSP solver %d", spsolver));
+        error('POUNDERS:badValue', sprintf("Unknown trust-region subproblem solver: %d", spsolver));
     end
 end

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -48,6 +48,7 @@ function [solver] = create_trsp_solver(spsolver)
 
     % ----- IDENTIFY DESIRED SOLVER
     if spsolver == TRSP_SOLVER_SIMPLE
+        printf("WARNING: The simple TRSP solver should only be used for testing or debugging");
         solver = @bqmin_wrapper;
     elseif spsolver == TRSP_SOLVER_MINQ5
         check_minq_installation(5);

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -1,6 +1,26 @@
 function [solver] = create_trsp_solver(spsolver)
     % Please refer to the documentation for the Python version of this
     % function.
+    %
+    % The returned solver satisfies the interface
+    %
+    % .. code:: matlab
+    %
+    %     [Xsp, mdec, found_solution] = solve_trsp(H, G, Low, Upp);
+    %
+    % where
+    %
+    % * ``H`` is an :math:`\np \times \np` matrix that provides the
+    %   (symmetric) Hessian of the objective function,
+    % * ``G`` is :math:`\np \times 1` vector that provides the
+    %   gradient of the objective function,
+    % * ``Low`` and ``Upp`` are :math:`1 \times \np` vectors that specify
+    %   the bound constraints,
+    % * ``Xsp`` :math:`\np \times 1` subproblem solution vector,
+    % * ``mdec`` is the value of the subproblem objective function at
+    %   the solution as a real scalar, and
+    % * ``found_solution`` is True if a solution was found that should be
+    %   acceptable for |pounders|'s purposes; False, otherwise.
 
     arguments
         spsolver {mustBeScalarOrEmpty, mustBeNonempty, mustBeInteger}

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -5,9 +5,12 @@ function [solver] = create_trsp_solver(spsolver)
     % ----- HARDCODED VALUES
     % Ensure that these match the analogous constants implemented for
     % POUNDERS/Python.
-    SIMPLE_TRSP = 1;
-    MINQ5_TRSP = 2;
-    MINQ8_TRSP = 3;
+    %
+    % Both MATLAB and Python implementations should declare the union of all
+    % solvers available even if they don't support one or more of the solvers.
+    TRSP_SOLVER_SIMPLE = 1;
+    TRSP_SOLVER_MINQ5 = 2;
+    TRSP_SOLVER_MINQ8 = 3;
 
     % ----- DEFINE POUNDERS-COMPATIBLE INTERFACES ON SOLVERS
     % Stefan's crappy 10 line solver
@@ -44,12 +47,12 @@ function [solver] = create_trsp_solver(spsolver)
     end
 
     % ----- IDENTIFY DESIRED SOLVER
-    if spsolver == SIMPLE_TRSP
+    if spsolver == TRSP_SOLVER_SIMPLE
         solver = @bqmin_wrapper;
-    elseif spsolver == MINQ5_TRSP
+    elseif spsolver == TRSP_SOLVER_MINQ5
         check_minq_installation(5);
         solver = @minq5_wrapper;
-    elseif spsolver == MINQ8_TRSP
+    elseif spsolver == TRSP_SOLVER_MINQ8
         check_minq_installation(8);
         solver = @minq8_wrapper;
     else

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -28,6 +28,11 @@ function [solver] = create_trsp_solver(spsolver)
         if minq_err < 0
             trsp_err = -4;
         end
+        % Continuous function restricted to (compact) k-cell.
+        assert(minq_err ~= 1);
+        % See comments in Python version of this function for info on handling
+        % error code 99.
+        % assert(minq_err ~= 99);
     end
 
     % Arnold Neumaier's minq8

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -2,9 +2,14 @@ function [solver] = create_trsp_solver(spsolver)
     % Please refer to the documentation for the Python version of this
     % function.
 
+    arguments
+        spsolver {mustBeScalarOrEmpty, mustBeNonempty, mustBeInteger}
+    end
+
     % ----- HARDCODED VALUES
     % Ensure that these match the analogous constants implemented for
-    % POUNDERS/Python.
+    % POUNDERS/Python.  These same values might be used in the code that
+    % directly tests this function.
     %
     % Both MATLAB and Python implementations should declare the union of all
     % solvers available even if they don't support one or more of the solvers.
@@ -53,7 +58,8 @@ function [solver] = create_trsp_solver(spsolver)
 
     % ----- IDENTIFY DESIRED SOLVER
     if spsolver == TRSP_SOLVER_SIMPLE
-        disp("WARNING: The simple TRSP solver should only be used for testing or debugging");
+        warning("POUNDERS:simpleTrspSolver", ...
+                "The simple TRSP solver should only be used for testing or debugging");
         solver = @bqmin_wrapper;
     elseif spsolver == TRSP_SOLVER_MINQ5
         check_minq_installation(5);
@@ -62,6 +68,6 @@ function [solver] = create_trsp_solver(spsolver)
         check_minq_installation(8);
         solver = @minq8_wrapper;
     else
-        error(sprintf("Invalid TRSP solver %d", spsolver));
+        error('POUNDERS:badValue', sprintf("Invalid TRSP solver %d", spsolver));
     end
 end

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -19,30 +19,31 @@ function [solver] = create_trsp_solver(spsolver)
 
     % ----- DEFINE POUNDERS-COMPATIBLE INTERFACES ON SOLVERS
     % Stefan's crappy 10 line solver
-    function [Xsp, mdec, trsp_err] = bqmin_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = bqmin_wrapper(H, G, Low, Upp)
         % Assume that solver error checks its arguments thoroughly and that
         % solver always finds valid solution.
-        trsp_err = 0;
+        found_solution = true;
         [Xsp, mdec] = bqmin(H, G, Low, Upp);
     end
 
     % Arnold Neumaier's minq5
-    function [Xsp, mdec, trsp_err] = minq5_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = minq5_wrapper(H, G, Low, Upp)
         % Assume that solver error checks its arguments thoroughly.
         xx = zeros(size(H, 1), 1);
-        [Xsp, mdec, trsp_err] = minqsw(0, G, H, Low', Upp', 0, xx);
+        [Xsp, mdec, minq_err] = minqsw(0, G, H, Low', Upp', 0, xx);
         % Continuous function restricted to (compact) k-cell.
-        assert(trsp_err ~= 1);
+        assert(minq_err ~= 1);
         % See comments in Python version of this function for info on handling
         % error code 99.
-        % assert(trsp_err ~= 99);
+        % assert(minq_err ~= 99);
+        found_solution = (minq_err >= 0);
     end
 
     % Arnold Neumaier's minq8
-    function [Xsp, mdec, trsp_err] = minq8_wrapper(H, G, Low, Upp)
+    function [Xsp, mdec, found_solution] = minq8_wrapper(H, G, Low, Upp)
         % Assume that solver error checks its arguments thoroughly and that
         % solver always finds valid solution.
-        trsp_err = 0;
+        found_solution = true;
 
         n = size(H, 1);
 

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -48,7 +48,7 @@ function [solver] = create_trsp_solver(spsolver)
 
     % ----- IDENTIFY DESIRED SOLVER
     if spsolver == TRSP_SOLVER_SIMPLE
-        printf("WARNING: The simple TRSP solver should only be used for testing or debugging");
+        disp("WARNING: The simple TRSP solver should only be used for testing or debugging");
         solver = @bqmin_wrapper;
     elseif spsolver == TRSP_SOLVER_MINQ5
         check_minq_installation(5);

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -1,22 +1,35 @@
 function [solver] = create_trsp_solver(spsolver)
-    % Please refer to the documentation for the Python version of this
-    % function.
+    % Create a MATLAB function that solves the bound-constrained trust-region
+    % subproblem (TRSP)
     %
-    % The returned solver satisfies the interface
+    % .. math::
+    %     \argmin_{\svec \in \R^{\np}}  \gvec^T \svec + \frac{1}{2}\svec^T H \svec
+    %
+    % such that
+    %
+    % .. math::
+    %     Low_j \leq s_j \le Upp_j
+    %
+    % for all components :math:`s_j` of :math:`\svec`.
+    %
+    % :param spsolver:
+    %     * 2 - Arnold Neumaier's minq5 solver
+    %     * 3 - Arnold Neumaier's minq8 solver
+    % :return: handle to MATLAB function with the interface
     %
     % .. code:: matlab
     %
-    %     [Xsp, mdec, found_solution] = solve_trsp(H, G, Low, Upp);
+    %     [Xsp, mdec, found_solution] = solve_trsp(H, g, Low, Upp);
     %
     % where
     %
     % * ``H`` is an :math:`\np \times \np` matrix that provides the
     %   (symmetric) Hessian of the objective function,
-    % * ``G`` is :math:`\np \times 1` vector that provides the
+    % * ``g`` is an :math:`\np \times 1` vector that provides the
     %   gradient of the objective function,
     % * ``Low`` and ``Upp`` are :math:`1 \times \np` vectors that specify
     %   the bound constraints,
-    % * ``Xsp`` :math:`\np \times 1` subproblem solution vector,
+    % * ``Xsp`` is the :math:`\np \times 1` subproblem solution vector,
     % * ``mdec`` is the value of the subproblem objective function at
     %   the solution as a real scalar, and
     % * ``found_solution`` is True if a solution was found that should be

--- a/pounders/m/create_trsp_solver.m
+++ b/pounders/m/create_trsp_solver.m
@@ -1,0 +1,58 @@
+function [solver] = create_trsp_solver(spsolver)
+    % Please refer to the documentation for the Python version of this
+    % function.
+
+    % ----- HARDCODED VALUES
+    % Ensure that these match the analogous constants implemented for
+    % POUNDERS/Python.
+    SIMPLE_TRSP = 1;
+    MINQ5_TRSP = 2;
+    MINQ8_TRSP = 3;
+
+    % ----- DEFINE POUNDERS-COMPATIBLE INTERFACES ON SOLVERS
+    % Stefan's crappy 10 line solver
+    function [Xsp, mdec, trsp_err] = bqmin_wrapper(H, G, Low, Upp)
+        trsp_err = 0;
+        [Xsp, mdec] = bqmin(H, G, Low, Upp);
+    end
+
+    % Arnold Neumaier's minq5
+    function [Xsp, mdec, trsp_err] = minq5_wrapper(H, G, Low, Upp)
+        trsp_err = 0;
+
+        xx = zeros(size(H, 1), 1);
+        [Xsp, mdec, minq_err] = minqsw(0, G, H, Low', Upp', 0, xx);
+        if minq_err < 0
+            trsp_err = -4;
+        end
+    end
+
+    % Arnold Neumaier's minq8
+    function [Xsp, mdec, trsp_err] = minq8_wrapper(H, G, Low, Upp)
+        trsp_err = 0;
+
+        n = size(H, 1);
+
+        data.gam = 0;
+        data.c = G;
+        data.b = zeros(n, 1);
+        [tmp1, tmp2] = ldl(H);
+        data.D = diag(tmp2);
+        data.A = tmp1';
+
+        [Xsp, mdec] = minq8(data, Low', Upp', zeros(n, 1), 10 * n);
+    end
+
+    % ----- IDENTIFY DESIRED SOLVER
+    if spsolver == SIMPLE_TRSP
+        solver = @bqmin_wrapper;
+    elseif spsolver == MINQ5_TRSP
+        check_minq_installation(5);
+        solver = @minq5_wrapper;
+    elseif spsolver == MINQ8_TRSP
+        check_minq_installation(8);
+        solver = @minq8_wrapper;
+    else
+        error(sprintf("Invalid TRSP solver %d", spsolver));
+    end
+end

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -340,8 +340,8 @@ while nf < nf_max
     % 3. Solve the subproblem min{G'*s+.5*s'*H*s : Lows <= s <= Upps }
     Lows = max(Low - X(xk_in, :), -delta);
     Upps = min(Upp - X(xk_in, :), delta);
-    [Xsp, mdec, trsp_err] = solve_trsp(H, G, Lows, Upps);
-    if trsp_err < 0
+    [Xsp, mdec, found_solution] = solve_trsp(H, G, Lows, Upps);
+    if ~found_solution
         [X, F, hF, flag] = prepare_outputs_before_return(X, F, hF, nf, -4);
         return
     end

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -39,7 +39,11 @@ function [X, F, hF, flag, xk_in] = pounders(Ffun, X_0, n, nf_max, g_tol, delta_0
 %           * 1 - Debugging level of output to screen
 %           * 2 - More verbose screen output
 %
-%       * **spsolver** - Trust-region subproblem solver flag (default is 2, not recommended to change)
+%       * **spsolver** - Trust-region subproblem solver flag
+%
+%           * 2 - Arnold Neumaier's minq5 solver (default and recommended)
+%           * 3 - Arnold Neumaier's minq8 solver
+%
 %       * **hfun** - Outer function :math:`\hfun` that maps given
 %         :math:`\Ffun(\psp)` to scalars for minimization (default is
 %         sum-of-squares that yields :math:`f`.)

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -342,7 +342,7 @@ while nf < nf_max
     Upps = min(Upp - X(xk_in, :), delta);
     [Xsp, mdec, trsp_err] = solve_trsp(H, G, Lows, Upps);
     if trsp_err < 0
-        [X, F, hF, flag] = prepare_outputs_before_return(X, F, hF, nf, trsp_err);
+        [X, F, hF, flag] = prepare_outputs_before_return(X, F, hF, nf, -4);
         return
     end
 

--- a/pounders/m/pounders.m
+++ b/pounders/m/pounders.m
@@ -116,7 +116,7 @@ if ~isfield(Options, 'delta_inact')
     Options.delta_inact = 0.75;
 end
 if ~isfield(Options, 'spsolver')
-    Options.spsolver = 2;
+    Options.spsolver = 2; % Use minq5 by default
 end
 
 if isfield(Options, 'hfun')
@@ -128,9 +128,6 @@ else
     addpath(fullfile(here_path, 'general_h_funs'));
     hfun = @h_leastsquares;
     combinemodels = @combine_leastsquares;
-end
-if ~isfield(Options, 'spsolver')
-    Options.spsolver = 2; % Use minq5 by default
 end
 if ~isfield(Options, 'printf')
     Options.printf = 0; % Don't print by default
@@ -152,7 +149,7 @@ end
 nfs = Prior.nfs;
 
 delta = delta_0;
-spsolver = Options.spsolver;
+solve_trsp = create_trsp_solver(Options.spsolver);
 delta_max = Options.delta_max;
 delta_min = Options.delta_min;
 gamma_dec = Options.gamma_dec;
@@ -160,12 +157,6 @@ gamma_inc = Options.gamma_inc;
 eta_1 = Options.eta_1;
 printf = Options.printf;
 delta_inact = Options.delta_inact;
-
-if spsolver == 2 % Arnold Neumaier's minq5
-%    check_minq_installation(5);
-elseif spsolver == 3 % Arnold Neumaier's minq8
-    check_minq_installation(8);
-end
 
 % 0. Check inputs
 [flag, X_0, np_max, F_0, Low, Upp, xk_in] = ...
@@ -345,26 +336,12 @@ while nf < nf_max
     % 3. Solve the subproblem min{G'*s+.5*s'*H*s : Lows <= s <= Upps }
     Lows = max(Low - X(xk_in, :), -delta);
     Upps = min(Upp - X(xk_in, :), delta);
-    if spsolver == 1 % Stefan's crappy 10line solver
-        [Xsp, mdec] = bqmin(H, G, Lows, Upps);
-    elseif spsolver == 2 % Arnold Neumaier's minq5
-        [Xsp, mdec, minq_err] = minqsw(0, G, H, Lows', Upps', 0, zeros(n, 1));
-        if minq_err < 0
-            [X, F, hF, flag] = prepare_outputs_before_return(X, F, hF, nf, -4);
-            return
-        end
-
-    elseif spsolver == 3 % Arnold Neumaier's minq8
-
-        data.gam = 0;
-        data.c = G;
-        data.b = zeros(n, 1);
-        [tmp1, tmp2] = ldl(H);
-        data.D = diag(tmp2);
-        data.A = tmp1';
-
-        [Xsp, mdec] = minq8(data, Lows', Upps', zeros(n, 1), 10 * n);
+    [Xsp, mdec, trsp_err] = solve_trsp(H, G, Lows, Upps);
+    if trsp_err < 0
+        [X, F, hF, flag] = prepare_outputs_before_return(X, F, hF, nf, trsp_err);
+        return
     end
+
     Xsp = Xsp'; % Solvers currently work with column vectors
     step_norm = norm(Xsp, inf);
 

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -41,9 +41,8 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             testCase.officialSolvers = [testCase.SOLVER_MINQ5, ...
                                         testCase.SOLVER_MINQ8];
 
-            testCase.emitWarnings = struct([]);
-            testCase.emitWarnings(1).solver = testCase.SOLVER_SIMPLE;
-            testCase.emitWarnings(1).warnID = testCase.WARNING_SIMPLE;
+            testCase.emitWarnings = dictionary(testCase.SOLVER_SIMPLE, ...
+                                               testCase.WARNING_SIMPLE);
 
             warning("on");
 
@@ -74,10 +73,14 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
         end
 
         function testWarnings(testCase)
-            for i = 1:length(testCase.emitWarnings)
-                idx = testCase.emitWarnings(i).solver;
-                warnID = testCase.emitWarnings(i).warnID;
-                testCase.assertWarning(@() create_trsp_solver(idx), warnID);
+            for i = 1:length(testCase.solvers)
+                idx = testCase.solvers(i);
+                if testCase.emitWarnings.isKey(idx)
+                    warnID = testCase.emitWarnings(i);
+                    testCase.assertWarning(@() create_trsp_solver(idx), warnID);
+                else
+                    testCase.assertWarningFree(@() create_trsp_solver(idx));
+                end
             end
         end
 
@@ -85,7 +88,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             % ----- SPECIFY PROBLEMS
             % Unconstrained solution inside bounds
             N = 1;
-            G = [-1.1];
+            g = [-1.1];
             H = [[2.2]];
             Low = [-1.9];
             Upp = [0.9];
@@ -105,18 +108,21 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             s_large = too_large(1);
             f_large = -22.0 / 125.0;
 
-            % Expected emission of specific warnings tested in testWarnings.
-            % Ignore only those to silence expected warnings without
-            % inadvertently silencing unintended warnings.
-            warning("off", testCase.WARNING_SIMPLE);
             for i = 1:length(testCase.solvers)
                 idx = testCase.solvers(i);
+
+                % Expected emission of specific warnings tested in
+                % testWarnings.  Ignore only those.
+                warning("on");
+                if testCase.emitWarnings.isKey(idx)
+                    warning("off", testCase.emitWarnings(idx));
+                end
 
                 solve_trsp = create_trsp_solver(idx);
                 testCase.assertTrue(isa(solve_trsp, 'function_handle'));
 
                 % Unconstrained solution in bounds
-                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                [s_0, f_0, found_solution] = solve_trsp(H, g, Low, Upp);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
                 testCase.assertEqual(size(s_0), [N 1]);
@@ -128,7 +134,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 testCase.assertTrue(rel_err <= 110.0 * eps);
 
                 % Unconstrained solution outside bounds
-                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, too_small);
+                [s_0, f_0, found_solution] = solve_trsp(H, g, Low, too_small);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
                 testCase.assertEqual(size(s_0), [N 1]);
@@ -140,7 +146,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
 
                 if idx ~= testCase.SOLVER_SIMPLE
                     % The simple sampler requires that Low <= 0 <= Upp
-                    [s_0, f_0, found_solution] = solve_trsp(H, G, too_large, Upp);
+                    [s_0, f_0, found_solution] = solve_trsp(H, g, too_large, Upp);
                     testCase.assertTrue(found_solution);
                     testCase.assertEqual(ndims(s_0), 2);
                     testCase.assertEqual(size(s_0), [N 1]);
@@ -151,13 +157,12 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                     testCase.assertTrue(rel_err <= 500.0 * eps);
                 end
             end
-            warning("on", testCase.WARNING_SIMPLE);
         end
 
         function test2D(testCase)
             % Specify problem
             N = 2;
-            G = [1.2; -2.3];
+            g = [1.2; -2.3];
             H = [[1.1 -1.2]
                  [-1.2 4.5]];
             [lambdas] = eig(H, "vector");
@@ -170,18 +175,21 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             s_expected = [-88.0 / 117.0; 109.0 / 351.0];
             f_expected = -1135.0 / 1404.0;
 
-            % Expected emission of specific warnings tested in testWarnings.
-            % Ignore only those to silence expected warnings without
-            % inadvertently silencing unintended warnings.
-            warning("off", testCase.WARNING_SIMPLE);
             for i = 1:length(testCase.solvers)
                 idx = testCase.solvers(i);
+
+                % Expected emission of specific warnings tested in
+                % testWarnings.  Ignore only those.
+                warning("on");
+                if testCase.emitWarnings.isKey(idx)
+                    warning("off", testCase.emitWarnings(idx));
+                end
 
                 solve_trsp = create_trsp_solver(idx);
                 testCase.assertTrue(isa(solve_trsp, 'function_handle'));
 
                 % Unconstrained solution in bounds
-                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                [s_0, f_0, found_solution] = solve_trsp(H, g, Low, Upp);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
                 testCase.assertEqual(size(s_0), [N 1]);
@@ -192,13 +200,12 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 rel_err = abs(1.0 - f_0 / f_expected);
                 testCase.assertTrue(rel_err <= 5.0e-14);
             end
-            warning("on", testCase.WARNING_SIMPLE);
         end
 
         function test5D(testCase)
             % Specify problem
             N = 5;
-            G = [1.2; -2.3; 0.7; -0.4; 3.4];
+            g = [1.2; -2.3; 0.7; -0.4; 3.4];
             H = [[30.25 38.5 115.5 -19.25 8.25]
                  [38.5 50.0 131.0 -14.5 5.5]
                  [115.5 131.0 818.0 -211.5 67.5]
@@ -226,11 +233,18 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             for i = 1:length(testCase.officialSolvers)
                 idx = testCase.officialSolvers(i);
 
+                % Expected emission of specific warnings tested in
+                % testWarnings.  Ignore only those.
+                warning("on");
+                if testCase.emitWarnings.isKey(idx)
+                    warning("off", testCase.emitWarnings(idx));
+                end
+
                 solve_trsp = create_trsp_solver(idx);
                 testCase.assertTrue(isa(solve_trsp, 'function_handle'));
 
                 % Unconstrained solution in bounds
-                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                [s_0, f_0, found_solution] = solve_trsp(H, g, Low, Upp);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
                 testCase.assertEqual(size(s_0), [N 1]);

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -155,8 +155,8 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             % Specify problem
             N = 2;
             G = [1.2; -2.3];
-            H = [[ 1.1 -1.2],
-                 [-1.2  4.5]];
+            H = [[1.1 -1.2]
+                 [-1.2 4.5]];
             [lambdas] = eig(H, "vector");
             testCase.assertTrue(isequal(H', H));
             testCase.assertTrue(all(lambdas > 0.5));
@@ -164,7 +164,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             Upp = [ 5.0  4.0];
 
             % Known solution
-            s_expected = [-0.75213675; 0.31054131]; 
+            s_expected = [-0.75213675; 0.31054131];
             f_expected = -0.8084045584045583;
 
             % Expected emission of specific warnings tested in testWarnings.
@@ -196,11 +196,11 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             % Specify problem
             N = 5;
             G = [1.2; -2.3; 0.7; -0.4; 3.4];
-            H = [[ 30.25,  38.5,  115.5,  -19.25,  8.25],
-                 [ 38.5,   50.0,  131.0,  -14.5,   5.5],
-                 [115.5,  131.0,  818.0, -211.5,  67.5],
-                 [-19.25, -14.5, -211.5,  388.5,  -5.5],
-                 [  8.25,   5.5,   67.5,   -5.5,  64.5]];
+            H = [[30.25 38.5 115.5 -19.25 8.25]
+                 [38.5 50.0 131.0 -14.5 5.5]
+                 [115.5 131.0 818.0 -211.5 67.5]
+                 [-19.25 -14.5 -211.5 388.5 -5.5]
+                 [8.25 5.5 67.5 -5.5 64.5]];
             [lambdas] = eig(H, "vector");
             testCase.assertTrue(isequal(H', H));
             testCase.assertTrue(all(lambdas > 0.01));
@@ -208,10 +208,10 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             Upp = [  10.0 100.0  3.0  0.5  7.0];
 
             % Known solution
-            s_expected = [-128.82782698;
-                            90.82291477;
-                             2.8264531;
-                            -1.37446078;
+            s_expected = [-128.82782698
+                            90.82291477
+                             2.8264531
+                            -1.37446078
                              5.60555695];
             f_expected = -170.94945062515922;
 

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -187,10 +187,10 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
-                max_rel_err = max(abs(1.0 - s_0 ./ s_expected))
-                testCase.assertTrue(max_rel_err <= 5.0e-9);
-                rel_err = abs(1.0 - f_0 / f_expected)
-                testCase.assertTrue(rel_err <= 75.0 * eps);
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                testCase.assertTrue(max_rel_err <= 5.0e-13);
+                rel_err = abs(1.0 - f_0 / f_expected);
+                testCase.assertTrue(rel_err <= 5.0e-14);
             end
             warning("on", testCase.WARNING_SIMPLE);
         end
@@ -236,9 +236,9 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
-                max_rel_err = max(abs(1.0 - s_0 ./ s_expected))
-                testCase.assertTrue(max_rel_err <= 2.5e-9);
-                rel_err = abs(1.0 - f_0 / f_expected)
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                testCase.assertTrue(max_rel_err <= 7.5e-11);
+                rel_err = abs(1.0 - f_0 / f_expected);
                 testCase.assertTrue(rel_err <= 7.5e-11);
             end
         end

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -76,7 +76,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             for i = 1:length(testCase.solvers)
                 idx = testCase.solvers(i);
                 if testCase.emitWarnings.isKey(idx)
-                    warnID = testCase.emitWarnings(i);
+                    warnID = testCase.emitWarnings(idx);
                     testCase.assertWarning(@() create_trsp_solver(idx), warnID);
                 else
                     testCase.assertWarningFree(@() create_trsp_solver(idx));

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -32,6 +32,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
     end
 
     methods (TestMethodSetup)
+
         function setUp(testCase)
             testCase.solvers = [testCase.SOLVER_SIMPLE, ...
                                 testCase.SOLVER_MINQ5, ...
@@ -46,15 +47,19 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             [here_path, ~, ~] = fileparts(mfilename('fullpath'));
             testCase.oldpath = addpath(fullfile(here_path, '..'));
         end
+
     end
 
     methods (TestMethodTeardown)
+
         function tearDown(testCase)
             path(testCase.oldpath);
         end
+
     end
 
     methods (Test)
+
         function testErrors(testCase)
             badSolvers = [min(testCase.solvers) - 1, ...
                           max(testCase.solvers) + 1];
@@ -73,18 +78,74 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             end
         end
 
-        function testSuccessful(testCase)
+        function test1D(testCase)
+            % Specify problem
+            G = [-1.1];
+            H = [[2.2]];
+            Low = [-1.9];
+            Upp = [0.9];
+            testCase.assertTrue(H(1, 1) > 0.0);
+
+            % Known solutions
+            s_expected = 0.5;
+            f_expected = -0.275;
+
+            too_small = [0.25];
+            s_small = too_small(1);
+            f_small = -0.20625;
+
+            too_large = [0.8];
+            s_large = too_large(1);
+            f_large = -0.176;
+
             % Expected emission of specific warnings tested in testWarnings.
             % Ignore only those to silence expected warnings without
             % inadvertently silencing unintended warnings.
             warning("off", testCase.WARNING_SIMPLE);
             for i = 1:length(testCase.solvers)
                 idx = testCase.solvers(i);
+
                 solve_trsp = create_trsp_solver(idx);
                 testCase.assertTrue(isa(solve_trsp, 'function_handle'));
+
+                % Unconstrained solution in bounds
+                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                testCase.assertTrue(found_solution);
+                testCase.assertEqual(ndims(s_0), 2);
+                testCase.assertEqual(size(s_0), [1 1]);
+                testCase.assertEqual(ndims(f_0), 2);
+                testCase.assertEqual(size(f_0), [1 1]);
+                rel_err = abs(1.0 - s_0 / s_expected);
+                testCase.assertTrue(rel_err <= 110.0 * eps);
+                rel_err = abs(1.0 - f_0 / f_expected);
+                testCase.assertTrue(rel_err <= 110.0 * eps);
+
+                % Unconstrained solution outside bounds
+                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, too_small);
+                testCase.assertTrue(found_solution);
+                testCase.assertEqual(ndims(s_0), 2);
+                testCase.assertEqual(size(s_0), [1 1]);
+                testCase.assertEqual(ndims(f_0), 2);
+                testCase.assertEqual(size(f_0), [1 1]);
+                testCase.assertEqual(s_0, s_small);
+                rel_err = abs(1.0 - f_0 / f_small);
+                testCase.assertTrue(rel_err <= 35.0 * eps);
+
+                if idx ~= testCase.SOLVER_SIMPLE
+                    % The simple sampler requires that Low <= 0 <= Upp
+                    [s_0, f_0, found_solution] = solve_trsp(H, G, too_large, Upp);
+                    testCase.assertTrue(found_solution);
+                    testCase.assertEqual(ndims(s_0), 2);
+                    testCase.assertEqual(size(s_0), [1 1]);
+                    testCase.assertEqual(ndims(f_0), 2);
+                    testCase.assertEqual(size(f_0), [1 1]);
+                    testCase.assertEqual(s_0, s_large);
+                    rel_err = abs(1.0 - f_0 / f_large);
+                    testCase.assertTrue(rel_err <= 500.0 * eps);
+                end
             end
             warning("on", testCase.WARNING_SIMPLE);
         end
-    end
 
+    end
 end

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -161,7 +161,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             testCase.assertTrue(isequal(H', H));
             testCase.assertTrue(all(lambdas > 0.5));
             Low = [-7.0 -4.0];
-            Upp = [ 5.0  4.0];
+            Upp = [5.0 4.0];
 
             % Known solution
             s_expected = [-0.75213675; 0.31054131];
@@ -205,7 +205,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             testCase.assertTrue(isequal(H', H));
             testCase.assertTrue(all(lambdas > 0.01));
             Low = [-150.0 -10.0 -1.0 -2.0 -1.0];
-            Upp = [  10.0 100.0  3.0  0.5  7.0];
+            Upp = [10.0 100.0 3.0 0.5 7.0];
 
             % Known solution
             s_expected = [-128.82782698

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -1,0 +1,90 @@
+% To run this test, you must first install a MINQ clone and add
+%    /path/to/MINQ/m/minq5
+%    /path/to/MINQ/m/minq8
+% to the MATLAB path.
+%
+% From MATLAB and the directory containing this file, execute
+%     >> runtests
+%
+% If you would like to run this from a different folder that includes these
+% tests as a subfolder, then from that folder execute
+%     >> runtests("IncludeSubfolders", true)
+%
+% To execute the test suite with coverage enabled and to generate an HTML-format
+% coverage report, execute from /path/to/IBCDFO/pounders/m
+%     >> runtests("IncludeSubfolders", true, "ReportCoverageFor", pwd)
+%
+
+classdef TestCreateTrspSolver < matlab.unittest.TestCase
+    properties (Constant)
+        WARNING_SIMPLE = 'POUNDERS:simpleTrspSolver'
+        ERROR_BAD_SOLVER = 'POUNDERS:badValue'
+        % These should match the values used in create_trsp_solver().
+        SOLVER_SIMPLE = 1
+        SOLVER_MINQ5 = 2
+        SOLVER_MINQ8 = 3
+    end
+
+    properties
+        oldpath
+        solvers
+        emitWarnings
+    end
+
+    methods (TestMethodSetup)
+        function setUp(testCase)
+            testCase.solvers = [testCase.SOLVER_SIMPLE, ...
+                                testCase.SOLVER_MINQ5, ...
+                                testCase.SOLVER_MINQ8];
+
+            testCase.emitWarnings = struct([]);
+            testCase.emitWarnings(1).solver = testCase.SOLVER_SIMPLE;
+            testCase.emitWarnings(1).warnID = testCase.WARNING_SIMPLE;
+
+            warning("on");
+
+            [here_path, ~, ~] = fileparts(mfilename('fullpath'));
+            testCase.oldpath = addpath(fullfile(here_path, '..'));
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function tearDown(testCase)
+            path(testCase.oldpath);
+        end
+    end
+
+    methods (Test)
+        function testErrors(testCase)
+            badSolvers = [min(testCase.solvers) - 1, ...
+                          max(testCase.solvers) + 1];
+            for i = 1:length(badSolvers)
+                bad = badSolvers(i);
+                testCase.assertError(@() create_trsp_solver(bad), ...
+                                     testCase.ERROR_BAD_SOLVER);
+            end
+        end
+
+        function testWarnings(testCase)
+            for i = 1:length(testCase.emitWarnings)
+                idx = testCase.emitWarnings(i).solver;
+                warnID = testCase.emitWarnings(i).warnID;
+                testCase.assertWarning(@() create_trsp_solver(idx), warnID);
+            end
+        end
+
+        function testSuccessful(testCase)
+            % Expected emission of specific warnings tested in testWarnings.
+            % Ignore only those to silence expected warnings without
+            % inadvertently silencing unintended warnings.
+            warning("off", testCase.WARNING_SIMPLE);
+            for i = 1:length(testCase.solvers)
+                idx = testCase.solvers(i);
+                solve_trsp = create_trsp_solver(idx);
+                testCase.assertTrue(isa(solve_trsp, 'function_handle'));
+            end
+            warning("on", testCase.WARNING_SIMPLE);
+        end
+    end
+
+end

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -28,6 +28,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
     properties
         oldpath
         solvers
+        officialSolvers
         emitWarnings
     end
 
@@ -37,6 +38,8 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             testCase.solvers = [testCase.SOLVER_SIMPLE, ...
                                 testCase.SOLVER_MINQ5, ...
                                 testCase.SOLVER_MINQ8];
+            testCase.officialSolvers = [testCase.SOLVER_MINQ5, ...
+                                        testCase.SOLVER_MINQ8];
 
             testCase.emitWarnings = struct([]);
             testCase.emitWarnings(1).solver = testCase.SOLVER_SIMPLE;
@@ -80,6 +83,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
 
         function test1D(testCase)
             % Specify problem
+            N = 1;
             G = [-1.1];
             H = [[2.2]];
             Low = [-1.9];
@@ -112,7 +116,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
-                testCase.assertEqual(size(s_0), [1 1]);
+                testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
                 rel_err = abs(1.0 - s_0 / s_expected);
@@ -124,7 +128,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 [s_0, f_0, found_solution] = solve_trsp(H, G, Low, too_small);
                 testCase.assertTrue(found_solution);
                 testCase.assertEqual(ndims(s_0), 2);
-                testCase.assertEqual(size(s_0), [1 1]);
+                testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
                 testCase.assertEqual(s_0, s_small);
@@ -136,7 +140,7 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                     [s_0, f_0, found_solution] = solve_trsp(H, G, too_large, Upp);
                     testCase.assertTrue(found_solution);
                     testCase.assertEqual(ndims(s_0), 2);
-                    testCase.assertEqual(size(s_0), [1 1]);
+                    testCase.assertEqual(size(s_0), [N 1]);
                     testCase.assertEqual(ndims(f_0), 2);
                     testCase.assertEqual(size(f_0), [1 1]);
                     testCase.assertEqual(s_0, s_large);
@@ -145,6 +149,95 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 end
             end
             warning("on", testCase.WARNING_SIMPLE);
+        end
+
+        function test2D(testCase)
+            % Specify problem
+            N = 2;
+            G = [1.2; -2.3];
+            H = [[ 1.1 -1.2],
+                 [-1.2  4.5]];
+            [lambdas] = eig(H, "vector");
+            testCase.assertTrue(isequal(H', H));
+            testCase.assertTrue(all(lambdas > 0.5));
+            Low = [-7.0 -4.0];
+            Upp = [ 5.0  4.0];
+
+            % Known solution
+            s_expected = [-0.75213675; 0.31054131]; 
+            f_expected = -0.8084045584045583;
+
+            % Expected emission of specific warnings tested in testWarnings.
+            % Ignore only those to silence expected warnings without
+            % inadvertently silencing unintended warnings.
+            warning("off", testCase.WARNING_SIMPLE);
+            for i = 1:length(testCase.solvers)
+                idx = testCase.solvers(i);
+
+                solve_trsp = create_trsp_solver(idx);
+                testCase.assertTrue(isa(solve_trsp, 'function_handle'));
+
+                % Unconstrained solution in bounds
+                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                testCase.assertTrue(found_solution);
+                testCase.assertEqual(ndims(s_0), 2);
+                testCase.assertEqual(size(s_0), [N 1]);
+                testCase.assertEqual(ndims(f_0), 2);
+                testCase.assertEqual(size(f_0), [1 1]);
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                testCase.assertTrue(max_rel_err <= 5.0e-9);
+                rel_err = abs(1.0 - f_0 / f_expected);
+                testCase.assertTrue(rel_err <= 75.0 * eps);
+            end
+            warning("on", testCase.WARNING_SIMPLE);
+        end
+
+        function test5D(testCase)
+            % Specify problem
+            N = 5;
+            G = [1.2; -2.3; 0.7; -0.4; 3.4];
+            H = [[ 30.25,  38.5,  115.5,  -19.25,  8.25],
+                 [ 38.5,   50.0,  131.0,  -14.5,   5.5],
+                 [115.5,  131.0,  818.0, -211.5,  67.5],
+                 [-19.25, -14.5, -211.5,  388.5,  -5.5],
+                 [  8.25,   5.5,   67.5,   -5.5,  64.5]];
+            [lambdas] = eig(H, "vector");
+            testCase.assertTrue(isequal(H', H));
+            testCase.assertTrue(all(lambdas > 0.01));
+            Low = [-150.0 -10.0 -1.0 -2.0 -1.0];
+            Upp = [  10.0 100.0  3.0  0.5  7.0];
+
+            % Known solution
+            s_expected = [-128.82782698;
+                            90.82291477;
+                             2.8264531;
+                            -1.37446078;
+                             5.60555695];
+            f_expected = -170.94945062515922;
+
+            % Setting maxit=600,000 in bqmin yielded a solution that was of
+            % similar quality to MINQ5's solution.  Since, that's far more that
+            % the real budget, we skip it.  We consider a passing 2D test as
+            % sufficient evidence of correct functionality for that unofficial
+            % solver.
+            for i = 1:length(testCase.officialSolvers)
+                idx = testCase.officialSolvers(i);
+
+                solve_trsp = create_trsp_solver(idx);
+                testCase.assertTrue(isa(solve_trsp, 'function_handle'));
+
+                % Unconstrained solution in bounds
+                [s_0, f_0, found_solution] = solve_trsp(H, G, Low, Upp);
+                testCase.assertTrue(found_solution);
+                testCase.assertEqual(ndims(s_0), 2);
+                testCase.assertEqual(size(s_0), [N 1]);
+                testCase.assertEqual(ndims(f_0), 2);
+                testCase.assertEqual(size(f_0), [1 1]);
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                testCase.assertTrue(max_rel_err <= 2.5e-9);
+                rel_err = abs(1.0 - f_0 / f_expected);
+                testCase.assertTrue(rel_err <= 7.5e-11);
+            end
         end
 
     end

--- a/pounders/m/tests/TestCreateTrspSolver.m
+++ b/pounders/m/tests/TestCreateTrspSolver.m
@@ -82,7 +82,8 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
         end
 
         function test1D(testCase)
-            % Specify problem
+            % ----- SPECIFY PROBLEMS
+            % Unconstrained solution inside bounds
             N = 1;
             G = [-1.1];
             H = [[2.2]];
@@ -90,17 +91,19 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             Upp = [0.9];
             testCase.assertTrue(H(1, 1) > 0.0);
 
+            % Bounds that put unconstrained solution outside bounds
+            too_small = [0.25];
+            too_large = [0.8];
+
             % Known solutions
             s_expected = 0.5;
-            f_expected = -0.275;
+            f_expected = -11.0 / 40.0;
 
-            too_small = [0.25];
             s_small = too_small(1);
-            f_small = -0.20625;
+            f_small = -33.0 / 160.0;
 
-            too_large = [0.8];
             s_large = too_large(1);
-            f_large = -0.176;
+            f_large = -22.0 / 125.0;
 
             % Expected emission of specific warnings tested in testWarnings.
             % Ignore only those to silence expected warnings without
@@ -164,8 +167,8 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             Upp = [5.0 4.0];
 
             % Known solution
-            s_expected = [-0.75213675; 0.31054131];
-            f_expected = -0.8084045584045583;
+            s_expected = [-88.0 / 117.0; 109.0 / 351.0];
+            f_expected = -1135.0 / 1404.0;
 
             % Expected emission of specific warnings tested in testWarnings.
             % Ignore only those to silence expected warnings without
@@ -184,9 +187,9 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
-                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected))
                 testCase.assertTrue(max_rel_err <= 5.0e-9);
-                rel_err = abs(1.0 - f_0 / f_expected);
+                rel_err = abs(1.0 - f_0 / f_expected)
                 testCase.assertTrue(rel_err <= 75.0 * eps);
             end
             warning("on", testCase.WARNING_SIMPLE);
@@ -208,12 +211,12 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
             Upp = [10.0 100.0 3.0 0.5 7.0];
 
             % Known solution
-            s_expected = [-128.82782698
-                            90.82291477
-                             2.8264531
-                            -1.37446078
-                             5.60555695];
-            f_expected = -170.94945062515922;
+            s_expected = [-18486334673.0 / 143496441.0
+                          1184796821.0 / 13045131.0
+                          368714509.0 / 130451310.0
+                          -16300019.0 / 11859210.0
+                          2014469.0 / 359370.0];
+            f_expected = -4906127551123.0 / 28699288200.0;
 
             % Setting maxit=600,000 in bqmin yielded a solution that was of
             % similar quality to MINQ5's solution.  Since, that's far more that
@@ -233,9 +236,9 @@ classdef TestCreateTrspSolver < matlab.unittest.TestCase
                 testCase.assertEqual(size(s_0), [N 1]);
                 testCase.assertEqual(ndims(f_0), 2);
                 testCase.assertEqual(size(f_0), [1 1]);
-                max_rel_err = max(abs(1.0 - s_0 ./ s_expected));
+                max_rel_err = max(abs(1.0 - s_0 ./ s_expected))
                 testCase.assertTrue(max_rel_err <= 2.5e-9);
-                rel_err = abs(1.0 - f_0 / f_expected);
+                rel_err = abs(1.0 - f_0 / f_expected)
                 testCase.assertTrue(rel_err <= 7.5e-11);
             end
         end

--- a/pounders/m/tests/benchmark_pounders.m
+++ b/pounders/m/tests/benchmark_pounders.m
@@ -95,6 +95,7 @@ for row = 1:length(dfo)
         Options.hfun = hfun;
         Options.combinemodels = combinemodels;
         Options.printf = printf;
+        Options.spsolver = spsolver;
 
         [X, F, hF, flag, xk_best] = pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, [], Options);
 

--- a/pounders/py/__init__.py
+++ b/pounders/py/__init__.py
@@ -17,6 +17,9 @@ from .general_h_funs import (
 # fmt: on
 from .create_squared_diff_from_mean_functions import create_squared_diff_from_mean_functions
 
+from .constants import SIMPLE_TRSP, MINQ5_TRSP
+from .create_trsp_solver import create_trsp_solver
+
 # -- Python unittest-based test framework
 # Used for automatic test discovery by main package
 from .load_tests import load_tests

--- a/pounders/py/__init__.py
+++ b/pounders/py/__init__.py
@@ -17,7 +17,9 @@ from .general_h_funs import (
 # fmt: on
 from .create_squared_diff_from_mean_functions import create_squared_diff_from_mean_functions
 
-from .constants import TRSP_SOLVER_SIMPLE, TRSP_SOLVER_MINQ5, TRSP_SOLVER_MINQ8
+# Do **not** put TRSP_SOLVER_SIMPLE in the public interface since it is for
+# testing/debugging purposes only.
+from .constants import TRSP_SOLVER_MINQ5, TRSP_SOLVER_MINQ8
 from .create_trsp_solver import create_trsp_solver
 
 # -- Python unittest-based test framework

--- a/pounders/py/__init__.py
+++ b/pounders/py/__init__.py
@@ -17,7 +17,7 @@ from .general_h_funs import (
 # fmt: on
 from .create_squared_diff_from_mean_functions import create_squared_diff_from_mean_functions
 
-from .constants import SIMPLE_TRSP, MINQ5_TRSP
+from .constants import TRSP_SOLVER_SIMPLE, TRSP_SOLVER_MINQ5, TRSP_SOLVER_MINQ8
 from .create_trsp_solver import create_trsp_solver
 
 # -- Python unittest-based test framework

--- a/pounders/py/constants.py
+++ b/pounders/py/constants.py
@@ -1,6 +1,9 @@
 # ----- TRUST-REGION SUBPROBLEM SOLVERS
 # Ensure that these match the analogous constants implemented for
 # POUNDERS/MATLAB.
-SIMPLE_TRSP = 1
-MINQ5_TRSP = 2
-MINQ8_TRSP = 3
+#
+# Both MATLAB and Python implementations should declare the union of all solvers
+# available even if they don't support one or more of the solvers.
+TRSP_SOLVER_SIMPLE = 1
+TRSP_SOLVER_MINQ5 = 2
+TRSP_SOLVER_MINQ8 = 3

--- a/pounders/py/constants.py
+++ b/pounders/py/constants.py
@@ -1,0 +1,6 @@
+# ----- TRUST-REGION SUBPROBLEM SOLVERS
+# Ensure that these match the analogous constants implemented for
+# POUNDERS/MATLAB.
+SIMPLE_TRSP = 1
+MINQ5_TRSP = 2
+MINQ8_TRSP = 3

--- a/pounders/py/constants.py
+++ b/pounders/py/constants.py
@@ -7,3 +7,6 @@
 TRSP_SOLVER_SIMPLE = 1
 TRSP_SOLVER_MINQ5 = 2
 TRSP_SOLVER_MINQ8 = 3
+
+# ----- ERROR & WARNING MESSAGES
+WARNING_SIMPLE_TRSP = "The simple TRSP solver should only be used for testing or debugging"

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-from .constants import SIMPLE_TRSP, MINQ5_TRSP
+from .constants import TRSP_SOLVER_SIMPLE, TRSP_SOLVER_MINQ5
 from .._get_minq_installation import get_minq_installation
 from .bqmin import bqmin
 
@@ -23,10 +23,10 @@ def create_trsp_solver(spsolver):
     for all components :math:`s_j` of :math:`\svec`.
 
     :param spsolver:
-        * ``ibcdfo.pounders.SIMPLE_TRSP`` - simplistic 10 line solver that is
+        * ``ibcdfo.pounders.TRSP_SOLVER_SIMPLE`` - simplistic 10 line solver that is
           included only for testing and maintenance purposes
-        * ``ibcdfo.pounders.MINQ5_TRSP`` - Arnold Neumaier's minq5 solver
-        * ``ibcdfo.pounders.MINQ8_TRSP`` - Arnold Neumaier's minq8 solver
+        * ``ibcdfo.pounders.TRSP_SOLVER_MINQ5`` - Arnold Neumaier's minq5 solver
+        * ``ibcdfo.pounders.TRSP_SOLVER_MINQ8`` - Arnold Neumaier's minq8 solver
     :return: Python function with the interface
 
         .. code:: python
@@ -47,7 +47,7 @@ def create_trsp_solver(spsolver):
         * ``flag`` communicates the termination condition of the solver with a
           negative value indicating failure.
     """
-    if spsolver == SIMPLE_TRSP:
+    if spsolver == TRSP_SOLVER_SIMPLE:
 
         def __bqmin_wrapper(H, G, Low, Upp):
             Xsp, mdec = bqmin(H, G, Low, Upp)
@@ -55,7 +55,7 @@ def create_trsp_solver(spsolver):
 
         return __bqmin_wrapper
 
-    elif spsolver == MINQ5_TRSP:
+    elif spsolver == TRSP_SOLVER_MINQ5:
         required_minq_SHA, minq_installation = get_minq_installation()
         if not minq_installation["is_valid"]:
             msg = f"Please set MINQ clone to git commit {required_minq_SHA}.\nSee User Guide (https://ibcdfo.readthedocs.io) for more information and instructions."

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -1,0 +1,78 @@
+import sys
+
+import numpy as np
+
+from .constants import SIMPLE_TRSP, MINQ5_TRSP
+from .._get_minq_installation import get_minq_installation
+from .bqmin import bqmin
+
+
+def create_trsp_solver(spsolver):
+    r"""
+    Create a Python function that solves the bound-constrained trust-region
+    subproblem
+
+    .. math::
+        \min_{\svec \in \R^{\np}}  G^T \svec + \frac{1}{2}\svec^T H \svec
+
+    such that
+
+    .. math::
+        Low_j \leq s_j \le Upp_j, j=1,...,\np
+
+    for all components :math:`s_j` of :math:`\svec`.
+
+    :param spsolver:
+        * ``ibcdfo.pounders.SIMPLE_TRSP`` - simplistic 10 line solver that is
+          included only for testing and maintenance purposes
+        * ``ibcdfo.pounders.MINQ5_TRSP`` - Arnold Neumaier's minq5 solver
+        * ``ibcdfo.pounders.MINQ8_TRSP`` - Arnold Neumaier's minq8 solver
+    :return: Python function with the interface
+
+        .. code:: python
+
+            Xsp, mdec, flag = solve_trsp(H, G, Low, Upp)
+
+        where
+
+        * ``H`` is an :math:`\np \times \np` numpy array that provides the
+          (symmetric) Hessian of the objective function,
+        * ``G`` is an :math:`\np` element numpy array that provides the gradient
+          of the objective function,
+        * ``Low`` and ``High`` are :math:`\np` element numpy arrays that specify
+          the bound constraints,
+        * ``Xsp`` is the subproblem solution,
+        * ``mdec`` is the value of the subproblem objective function at
+          solution, and
+        * ``flag`` communicates the termination condition of the solver with a
+          negative value indicating failure.
+    """
+    if spsolver == SIMPLE_TRSP:
+
+        def __bqmin_wrapper(H, G, Low, Upp):
+            Xsp, mdec = bqmin(H, G, Low, Upp)
+            return Xsp, mdec, 0
+
+        return __bqmin_wrapper
+
+    elif spsolver == MINQ5_TRSP:
+        required_minq_SHA, minq_installation = get_minq_installation()
+        if not minq_installation["is_valid"]:
+            msg = f"Please set MINQ clone to git commit {required_minq_SHA}.\nSee User Guide (https://ibcdfo.readthedocs.io) for more information and instructions."
+            sys.exit(msg)
+
+        # Implement in such away that users that would like to use a non-MINQ
+        # solver don't have to install MINQ.  In other words, allow MINQ to be
+        # an *optional* external dependence.
+        from minqsw import minqsw
+
+        def __minq5_wrapper(H, G, Low, Upp):
+            n = H.shape[0]
+            Xsp, mdec, minq_err, _ = minqsw(0, G, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
+            if minq_err < 0:
+                return Xsp, mdec, -4
+            return Xsp, mdec, 0
+
+        return __minq5_wrapper
+
+    raise ValueError(f"Unknown trust-region subproblem solver: {spsolver}")

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -11,15 +11,15 @@ from .bqmin import bqmin
 def create_trsp_solver(spsolver):
     r"""
     Create a Python function that solves the bound-constrained trust-region
-    subproblem
+    subproblem (TRSP)
 
     .. math::
-        \argmin_{\svec \in \R^{\np}}  G^T \svec + \frac{1}{2}\svec^T H \svec
+        \argmin_{\svec \in \R^{\np}}  \gvec^T \svec + \frac{1}{2}\svec^T H \svec
 
     such that
 
     .. math::
-        Low_j \leq s_j \le Upp_j, j=1,...,\np
+        Low_j \leq s_j \le Upp_j
 
     for all components :math:`s_j` of :math:`\svec`.
 
@@ -30,17 +30,18 @@ def create_trsp_solver(spsolver):
 
         .. code:: python
 
-            Xsp, mdec, found_solution = solve_trsp(H, G, Low, Upp)
+            Xsp, mdec, found_solution = solve_trsp(H, g, Low, Upp)
 
         where
 
         * ``H`` is an :math:`\np \times \np` Numpy array that provides the
           (symmetric) Hessian of the objective function,
-        * ``G`` is an :math:`\np` element Numpy array that provides the gradient
+        * ``g`` is an :math:`\np` element Numpy array that provides the gradient
           of the objective function,
         * ``Low`` and ``Upp`` are :math:`\np` element Numpy arrays that specify
           the bound constraints,
-        * ``Xsp`` is the subproblem solution as a 1D Numpy array,
+        * ``Xsp`` is the subproblem solution as an :math:`\np` element Numpy
+          array,
         * ``mdec`` is the value of the subproblem objective function at
           the solution as a real scalar, and
         * ``found_solution`` is True if a solution was found that should be

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 
-from .constants import TRSP_SOLVER_SIMPLE, TRSP_SOLVER_MINQ5
+from .constants import TRSP_SOLVER_SIMPLE, TRSP_SOLVER_MINQ5, WARNING_SIMPLE_TRSP
 from .._get_minq_installation import get_minq_installation
 from .bqmin import bqmin
 
@@ -51,11 +51,11 @@ def create_trsp_solver(spsolver):
         # Since this solver is for testing/debugging only, we do not mention it
         # in the documentation nor do we put it in the package's public
         # interface.
-        warnings.warn("The simple TRSP solver should only be used for testing or debugging")
+        warnings.warn(WARNING_SIMPLE_TRSP)
 
-        def __bqmin_wrapper(H, G, Low, Upp):
+        def __bqmin_wrapper(H, g, Low, Upp):
             # Assume that solver error checks its arguments thoroughly.
-            Xsp, mdec = bqmin(H, G, Low, Upp)
+            Xsp, mdec = bqmin(H, g, Low, Upp)
             return Xsp, mdec, True
 
         return __bqmin_wrapper
@@ -70,10 +70,10 @@ def create_trsp_solver(spsolver):
             sys.exit(msg)
         from minqsw import minqsw
 
-        def __minq5_wrapper(H, G, Low, Upp):
+        def __minq5_wrapper(H, g, Low, Upp):
             # Assume that solver error checks its arguments thoroughly.
             n = H.shape[0]
-            Xsp, mdec, minq_err, _ = minqsw(0, G, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
+            Xsp, mdec, minq_err, _ = minqsw(0, g, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
             Xsp = np.atleast_1d(np.squeeze(Xsp))
             mdec = float(np.squeeze(mdec))
 

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -74,6 +74,16 @@ def create_trsp_solver(spsolver):
             Xsp, mdec, minq_err, _ = minqsw(0, G, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
             if minq_err < 0:
                 return Xsp, mdec, -4
+            # Continuous function restricted to (compact) k-cell.
+            assert minq_err != 1
+            # TODO: Since we are solving a subproblem, there is likely no sense
+            # in spending an excessive number of iterations seeking a slightly
+            # better approximation to the solution.  But, it might be useful for
+            # developers/power users to be able to identify when the budget
+            # limit is reached.  Once we have improved logging, print debug
+            # messages at high-verbosity level if minq_err == 99?  Better to
+            # return that error code and let POUNDERS log?
+            # assert minq_err != 99
             return Xsp, mdec, 0
 
         return __minq5_wrapper

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -44,7 +44,7 @@ def create_trsp_solver(spsolver):
         * ``mdec`` is the value of the subproblem objective function at
           the solution as a real scalar, and
         * ``found_solution`` is True if a solution was found that should be
-          acceptable for POUNDERS's purposes; False, otherwise.
+          acceptable for |pounders|'s purposes; False, otherwise.
     """
     if spsolver == TRSP_SOLVER_SIMPLE:
         # Since this solver is for testing/debugging only, we do not mention it

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -30,7 +30,7 @@ def create_trsp_solver(spsolver):
 
         .. code:: python
 
-            Xsp, mdec, flag = solve_trsp(H, G, Low, Upp)
+            Xsp, mdec, found_solution = solve_trsp(H, G, Low, Upp)
 
         where
 
@@ -43,9 +43,8 @@ def create_trsp_solver(spsolver):
         * ``Xsp`` is the subproblem solution,
         * ``mdec`` is the value of the subproblem objective function at
           the solution, and
-        * ``flag`` communicates the termination condition of the solver with a
-          negative value indicating failure and all other values indicating
-          success.
+        * ``found_solution`` is True if a solution was found that should be
+          acceptable for POUNDERS's purposes; False, otherwise.
     """
     if spsolver == TRSP_SOLVER_SIMPLE:
         # Since this solver is for testing/debugging only, we do not mention it
@@ -56,7 +55,7 @@ def create_trsp_solver(spsolver):
         def __bqmin_wrapper(H, G, Low, Upp):
             # Assume that solver error checks its arguments thoroughly.
             Xsp, mdec = bqmin(H, G, Low, Upp)
-            return Xsp, mdec, 0
+            return Xsp, mdec, True
 
         return __bqmin_wrapper
 
@@ -81,10 +80,11 @@ def create_trsp_solver(spsolver):
             # better approximation to the solution.  But, it might be useful for
             # developers/power users to be able to identify when the budget
             # limit is reached.  Once we have improved logging, print debug
-            # messages at high verbosity levels if minq_err == 99?  Better to
-            # let POUNDERS log?
+            # messages at high verbosity levels if minq_err == 99?  Since we are
+            # returing a boolean, all logging would have to be done by this
+            # wrapper layer.
             # assert minq_err != 99
-            return Xsp, mdec, minq_err
+            return Xsp, mdec, (minq_err >= 0)
 
         return __minq5_wrapper
 

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -40,9 +40,9 @@ def create_trsp_solver(spsolver):
           of the objective function,
         * ``Low`` and ``Upp`` are :math:`\np` element Numpy arrays that specify
           the bound constraints,
-        * ``Xsp`` is the subproblem solution,
+        * ``Xsp`` is the subproblem solution as a 1D Numpy array,
         * ``mdec`` is the value of the subproblem objective function at
-          the solution, and
+          the solution as a real scalar, and
         * ``found_solution`` is True if a solution was found that should be
           acceptable for POUNDERS's purposes; False, otherwise.
     """
@@ -73,6 +73,9 @@ def create_trsp_solver(spsolver):
             # Assume that solver error checks its arguments thoroughly.
             n = H.shape[0]
             Xsp, mdec, minq_err, _ = minqsw(0, G, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
+            Xsp = np.atleast_1d(np.squeeze(Xsp))
+            mdec = float(np.squeeze(mdec))
+
             # Continuous function restricted to (compact) k-cell.
             assert minq_err != 1
             # TODO: Since we are solving a subproblem, there is likely no sense
@@ -81,7 +84,7 @@ def create_trsp_solver(spsolver):
             # developers/power users to be able to identify when the budget
             # limit is reached.  Once we have improved logging, print debug
             # messages at high verbosity levels if minq_err == 99?  Since we are
-            # returing a boolean, all logging would have to be done by this
+            # returning a boolean, all logging would have to be done by this
             # wrapper layer.
             # assert minq_err != 99
             return Xsp, mdec, (minq_err >= 0)

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 
@@ -23,8 +24,6 @@ def create_trsp_solver(spsolver):
     for all components :math:`s_j` of :math:`\svec`.
 
     :param spsolver:
-        * ``ibcdfo.pounders.TRSP_SOLVER_SIMPLE`` - simplistic 10 line solver that is
-          included only for testing and maintenance purposes
         * ``ibcdfo.pounders.TRSP_SOLVER_MINQ5`` - Arnold Neumaier's minq5 solver
         * ``ibcdfo.pounders.TRSP_SOLVER_MINQ8`` - Arnold Neumaier's minq8 solver
     :return: Python function with the interface
@@ -48,6 +47,10 @@ def create_trsp_solver(spsolver):
           negative value indicating failure.
     """
     if spsolver == TRSP_SOLVER_SIMPLE:
+        # Since this solver is for testing/debugging only, we do not mention it
+        # in the documentation nor do we put it in the package's public
+        # interface.
+        warnings.warn("The simple TRSP solver should only be used for testing or debugging")
 
         def __bqmin_wrapper(H, G, Low, Upp):
             Xsp, mdec = bqmin(H, G, Low, Upp)

--- a/pounders/py/create_trsp_solver.py
+++ b/pounders/py/create_trsp_solver.py
@@ -14,7 +14,7 @@ def create_trsp_solver(spsolver):
     subproblem
 
     .. math::
-        \min_{\svec \in \R^{\np}}  G^T \svec + \frac{1}{2}\svec^T H \svec
+        \argmin_{\svec \in \R^{\np}}  G^T \svec + \frac{1}{2}\svec^T H \svec
 
     such that
 
@@ -34,17 +34,18 @@ def create_trsp_solver(spsolver):
 
         where
 
-        * ``H`` is an :math:`\np \times \np` numpy array that provides the
+        * ``H`` is an :math:`\np \times \np` Numpy array that provides the
           (symmetric) Hessian of the objective function,
-        * ``G`` is an :math:`\np` element numpy array that provides the gradient
+        * ``G`` is an :math:`\np` element Numpy array that provides the gradient
           of the objective function,
-        * ``Low`` and ``High`` are :math:`\np` element numpy arrays that specify
+        * ``Low`` and ``Upp`` are :math:`\np` element Numpy arrays that specify
           the bound constraints,
         * ``Xsp`` is the subproblem solution,
         * ``mdec`` is the value of the subproblem objective function at
-          solution, and
+          the solution, and
         * ``flag`` communicates the termination condition of the solver with a
-          negative value indicating failure.
+          negative value indicating failure and all other values indicating
+          success.
     """
     if spsolver == TRSP_SOLVER_SIMPLE:
         # Since this solver is for testing/debugging only, we do not mention it
@@ -53,27 +54,26 @@ def create_trsp_solver(spsolver):
         warnings.warn("The simple TRSP solver should only be used for testing or debugging")
 
         def __bqmin_wrapper(H, G, Low, Upp):
+            # Assume that solver error checks its arguments thoroughly.
             Xsp, mdec = bqmin(H, G, Low, Upp)
             return Xsp, mdec, 0
 
         return __bqmin_wrapper
 
     elif spsolver == TRSP_SOLVER_MINQ5:
+        # Implement in such a way that users that would like to use a non-MINQ
+        # solver don't have to install MINQ.  In other words, allow MINQ to be
+        # an *optional* external dependence.
         required_minq_SHA, minq_installation = get_minq_installation()
         if not minq_installation["is_valid"]:
             msg = f"Please set MINQ clone to git commit {required_minq_SHA}.\nSee User Guide (https://ibcdfo.readthedocs.io) for more information and instructions."
             sys.exit(msg)
-
-        # Implement in such away that users that would like to use a non-MINQ
-        # solver don't have to install MINQ.  In other words, allow MINQ to be
-        # an *optional* external dependence.
         from minqsw import minqsw
 
         def __minq5_wrapper(H, G, Low, Upp):
+            # Assume that solver error checks its arguments thoroughly.
             n = H.shape[0]
             Xsp, mdec, minq_err, _ = minqsw(0, G, H, Low.T, Upp.T, 0, np.zeros((n, 1)))
-            if minq_err < 0:
-                return Xsp, mdec, -4
             # Continuous function restricted to (compact) k-cell.
             assert minq_err != 1
             # TODO: Since we are solving a subproblem, there is likely no sense
@@ -81,10 +81,10 @@ def create_trsp_solver(spsolver):
             # better approximation to the solution.  But, it might be useful for
             # developers/power users to be able to identify when the budget
             # limit is reached.  Once we have improved logging, print debug
-            # messages at high-verbosity level if minq_err == 99?  Better to
-            # return that error code and let POUNDERS log?
+            # messages at high verbosity levels if minq_err == 99?  Better to
+            # let POUNDERS log?
             # assert minq_err != 99
-            return Xsp, mdec, 0
+            return Xsp, mdec, minq_err
 
         return __minq5_wrapper
 

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -259,8 +259,8 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         # 3. Solve the subproblem min{G.T * s + 0.5 * s.T * H * s : Lows <= s <= Upps }
         Lows = np.maximum(Low - X[xk_in], -delta * np.ones((np.shape(Low))))
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
-        [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
-        if not trsp_flag:
+        [Xsp, mdec, found_solution] = solve_trsp(H, G, Lows, Upps)
+        if not found_solution:
             X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
             return X, F, hF, flag, xk_in
 

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -70,8 +70,8 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
             * 2 - More verbose screen output
 
         * **spsolver** - Trust-region subproblem solver flag
- 
-            * 2 - Arnold Neumaier's minq5 solver (default)
+
+            * ``ibcdfo.pounders.TRSP_SOLVER_MINQ5`` - Arnold Neumaier's minq5 solver (default)
 
         * **hfun** - Outer function :math:`\hfun` that maps given
           :math:`\Ffun(\psp)` to scalars for minimization (default is

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 
 from .._get_minq_installation import get_minq_installation
+from .create_trsp_solver import create_trsp_solver
 from .bmpts import bmpts
 from .bqmin import bqmin
 from .checkinputss import checkinputss
@@ -140,12 +141,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         from .general_h_funs import combine_leastsquares as combinemodels
 
     # choose your spsolver
-    if spsolver == 2:
-        required_minq_SHA, minq_installation = get_minq_installation()
-        if not minq_installation["is_valid"]:
-            msg = f"Please set MINQ clone to git commit {required_minq_SHA}.\nSee User Guide (https://ibcdfo.readthedocs.io) for more information and instructions."
-            sys.exit(msg)
-        from minqsw import minqsw
+    solve_trsp = create_trsp_solver(spsolver)
 
     [flag, X_0, _, F_init, Low, Upp, xk_in] = checkinputss(Ffun, X_0, n, Model["np_max"], nf_max, g_tol, delta_0, Prior["nfs"], m, Prior["X_init"], Prior["F_init"], Prior["xk_in"], Low, Upp)
     if flag == -1:
@@ -264,16 +260,11 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         # 3. Solve the subproblem min{G.T * s + 0.5 * s.T * H * s : Lows <= s <= Upps }
         Lows = np.maximum(Low - X[xk_in], -delta * np.ones((np.shape(Low))))
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
-        if spsolver == 1:  # Stefan's crappy 10line solver
-            [Xsp, mdec] = bqmin(H, G, Lows, Upps)
-        elif spsolver == 2:  # Arnold Neumaier's minq5
-            [Xsp, mdec, minq_err, _] = minqsw(0, G, H, Lows.T, Upps.T, 0, np.zeros((n, 1)))
-            if minq_err < 0:
-                X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
-                return X, F, hF, flag, xk_in
-        # elif spsolver == 3:  # Arnold Neumaier's minq8
-        #     [Xsp, mdec, minq_err, _] = minq8(0, G, H, Lows.T, Upps.T, 0, np.zeros((n, 1)))
-        #     assert minq_err >= 0, "Input error in minq"
+        [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
+        if trsp_flag < 0:
+            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, trsp_flag)
+            return X, F, hF, flag, xk_in
+
         Xsp = Xsp.squeeze()
         step_norm = np.linalg.norm(Xsp, np.inf) if n > 1 else np.abs(Xsp)
 

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -261,7 +261,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
         [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
         if trsp_flag < 0:
-            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, trsp_flag)
+            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
             return X, F, hF, flag, xk_in
 
         Xsp = Xsp.squeeze()

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -69,7 +69,10 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
             * 1 - Debugging level of output to screen
             * 2 - More verbose screen output
 
-        * **spsolver** - Trust-region subproblem solver flag (default is 2, not recommended to change)
+        * **spsolver** - Trust-region subproblem solver flag
+ 
+            * 2 - Arnold Neumaier's minq5 solver (default)
+
         * **hfun** - Outer function :math:`\hfun` that maps given
           :math:`\Ffun(\psp)` to scalars for minimization (default is
           sum-of-squares that yields :math:`f`)

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -1,11 +1,7 @@
-import sys
-
 import numpy as np
 
-from .._get_minq_installation import get_minq_installation
 from .create_trsp_solver import create_trsp_solver
 from .bmpts import bmpts
-from .bqmin import bqmin
 from .checkinputss import checkinputss
 from .formquad import formquad
 from .prepare_outputs_before_return import prepare_outputs_before_return

--- a/pounders/py/pounders.py
+++ b/pounders/py/pounders.py
@@ -260,11 +260,10 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         Lows = np.maximum(Low - X[xk_in], -delta * np.ones((np.shape(Low))))
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
         [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
-        if trsp_flag < 0:
+        if not trsp_flag:
             X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
             return X, F, hF, flag, xk_in
 
-        Xsp = Xsp.squeeze()
         step_norm = np.linalg.norm(Xsp, np.inf) if n > 1 else np.abs(Xsp)
 
         # 4. Evaluate the function at the new point (provided the model is

--- a/pounders/py/pounders_concurrent.py
+++ b/pounders/py/pounders_concurrent.py
@@ -227,7 +227,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
         [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
         if trsp_flag < 0:
-            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, trsp_flag)
+            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
             return X, F, hF, flag, xk_in
 
         Xsp = Xsp.squeeze()

--- a/pounders/py/pounders_concurrent.py
+++ b/pounders/py/pounders_concurrent.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 
 from .._get_minq_installation import get_minq_installation
+from .create_trsp_solver import create_trsp_solver
 from .bmpts import bmpts
 from .bqmin import bqmin
 from .checkinputss import checkinputss
@@ -101,12 +102,7 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         from .general_h_funs import combine_leastsquares as combinemodels
 
     # choose your spsolver
-    if spsolver == 2:
-        required_minq_SHA, minq_installation = get_minq_installation()
-        if not minq_installation["is_valid"]:
-            msg = f"Please set MINQ clone to git commit {required_minq_SHA}.\nSee User Guide (https://ibcdfo.readthedocs.io) for more information and instructions."
-            sys.exit(msg)
-        from minqsw import minqsw
+    solve_trsp = create_trsp_solver(spsolver)
 
     [flag, X_0, _, F_init, Low, Upp, xk_in] = checkinputss(Ffun, X_0, n, Model["np_max"], nf_max, g_tol, delta_0, Prior["nfs"], m, Prior["X_init"], Prior["F_init"], Prior["xk_in"], Low, Upp)
     if flag == -1:
@@ -233,16 +229,11 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         # 3. Solve the subproblem min{G.T * s + 0.5 * s.T * H * s : Lows <= s <= Upps }
         Lows = np.maximum(Low - X[xk_in], -delta * np.ones((np.shape(Low))))
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
-        if spsolver == 1:  # Stefan's crappy 10line solver
-            [Xsp, mdec] = bqmin(H, G, Lows, Upps)
-        elif spsolver == 2:  # Arnold Neumaier's minq5
-            [Xsp, mdec, minq_err, _] = minqsw(0, G, H, Lows.T, Upps.T, 0, np.zeros((n, 1)))
-            if minq_err < 0:
-                X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
-                return X, F, hF, flag, xk_in
-        # elif spsolver == 3:  # Arnold Neumaier's minq8
-        #     [Xsp, mdec, minq_err, _] = minq8(0, G, H, Lows.T, Upps.T, 0, np.zeros((n, 1)))
-        #     assert minq_err >= 0, "Input error in minq"
+        [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
+        if trsp_flag < 0:
+            X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, trsp_flag)
+            return X, F, hF, flag, xk_in
+
         Xsp = Xsp.squeeze()
         step_norm = np.linalg.norm(Xsp, np.inf) if n > 1 else np.abs(Xsp)
 

--- a/pounders/py/pounders_concurrent.py
+++ b/pounders/py/pounders_concurrent.py
@@ -225,12 +225,11 @@ def pounders(Ffun, X_0, n, nf_max, g_tol, delta_0, m, Low, Upp, Prior=None, Opti
         # 3. Solve the subproblem min{G.T * s + 0.5 * s.T * H * s : Lows <= s <= Upps }
         Lows = np.maximum(Low - X[xk_in], -delta * np.ones((np.shape(Low))))
         Upps = np.minimum(Upp - X[xk_in], delta * np.ones((np.shape(Upp))))
-        [Xsp, mdec, trsp_flag] = solve_trsp(H, G, Lows, Upps)
-        if trsp_flag < 0:
+        [Xsp, mdec, found_solution] = solve_trsp(H, G, Lows, Upps)
+        if not found_solution:
             X, F, hF, flag = prepare_outputs_before_return(X, F, hF, nf, -4)
             return X, F, hF, flag, xk_in
 
-        Xsp = Xsp.squeeze()
         step_norm = np.linalg.norm(Xsp, np.inf) if n > 1 else np.abs(Xsp)
 
         # 4. Evaluate the function at the new point (provided the model is

--- a/pounders/py/pounders_concurrent.py
+++ b/pounders/py/pounders_concurrent.py
@@ -1,11 +1,7 @@
-import sys
-
 import numpy as np
 
-from .._get_minq_installation import get_minq_installation
 from .create_trsp_solver import create_trsp_solver
 from .bmpts import bmpts
-from .bqmin import bqmin
 from .checkinputss import checkinputss
 from .formquad import formquad
 from .prepare_outputs_before_return import prepare_outputs_before_return

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -63,10 +63,8 @@ class TestCreateTrspSolver(unittest.TestCase):
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
             warnings.simplefilter("default")
-            for warn_idx, msg in self.__emit_warnings.items():
-                if warn_idx == idx:
-                    warnings.filterwarnings("ignore", message=msg)
-                    break
+            if idx in self.__emit_warnings:
+                warnings.filterwarnings("ignore", message=self.__emit_warnings[idx])
 
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
@@ -89,7 +87,7 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
             self.assertEqual(s_0[0], s_small)
-            self.assertTrue(np.fabs(1.0 - f_0 / f_small) <= 110.0 * EPS)
+            self.assertTrue(np.fabs(1.0 - f_0 / f_small) <= 75.0 * EPS)
 
             if idx != ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE:
                 # The simple sampler requires that Low <= 0 <= Upp
@@ -119,10 +117,8 @@ class TestCreateTrspSolver(unittest.TestCase):
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
             warnings.simplefilter("default")
-            for warn_idx, msg in self.__emit_warnings.items():
-                if warn_idx == idx:
-                    warnings.filterwarnings("ignore", message=msg)
-                    break
+            if idx in self.__emit_warnings:
+                warnings.filterwarnings("ignore", message=self.__emit_warnings[idx])
 
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
@@ -161,6 +157,11 @@ class TestCreateTrspSolver(unittest.TestCase):
         f_expected = -4906127551123.0 / 28699288200.0
 
         for idx in self.__solvers.difference(TO_SKIP):
+            # Expected emission of warnings tested in testWarnings.  Ignore only those.
+            warnings.simplefilter("default")
+            if idx in self.__emit_warnings:
+                warnings.filterwarnings("ignore", message=self.__emit_warnings[idx])
+
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
 

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -2,8 +2,11 @@
 Unit test of create_trsp_solver()
 """
 
+import numbers
 import warnings
 import unittest
+
+import numpy as np
 
 import ibcdfo
 
@@ -27,7 +30,28 @@ class TestCreateTrspSolver(unittest.TestCase):
                 for each in words:
                     self.assertTrue(each in str(w[0].message))
 
-    def testSuccessful(self):
+    def test1D(self):
+        EPS = np.finfo(float).eps
+
+        # Specify problem
+        G = np.array([-1.1])
+        H = np.atleast_2d([2.2])
+        Low = np.array([-1.9])
+        Upp = np.array([0.9])
+        self.assertTrue(H[0] > 0.0)
+
+        # Known solutions
+        s_expected = 0.5
+        f_expected = -0.275
+
+        too_small = np.array([0.25])
+        s_small = too_small[0]
+        f_small = -0.20625
+
+        too_large = np.array([0.8])
+        s_large = too_large[0]
+        f_large = -0.176
+
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
             warnings.simplefilter("default")
@@ -38,3 +62,33 @@ class TestCreateTrspSolver(unittest.TestCase):
 
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
+
+            # Unconstrained solution in bounds
+            s_0, f_0, was_successful = solve_trsp(H, G, Low, Upp)
+            self.assertTrue(was_successful)
+            self.assertTrue(isinstance(s_0, np.ndarray))
+            self.assertEqual(s_0.ndim, 1)
+            self.assertEqual(len(s_0), 1)
+            self.assertTrue(isinstance(f_0, numbers.Real))
+            self.assertTrue(np.fabs(1.0 - s_0[0] / s_expected) <= 110.0 * EPS)
+            self.assertTrue(np.fabs(1.0 - f_0 / f_expected) <= 110.0 * EPS)
+
+            # Unconstrained solution outside bounds
+            s_0, f_0, was_successful = solve_trsp(H, G, Low, too_small)
+            self.assertTrue(was_successful)
+            self.assertTrue(isinstance(s_0, np.ndarray))
+            self.assertEqual(s_0.ndim, 1)
+            self.assertEqual(len(s_0), 1)
+            self.assertTrue(isinstance(f_0, numbers.Real))
+            self.assertTrue(np.fabs(1.0 - s_0[0] / s_small) <= 110.0 * EPS)
+            self.assertTrue(np.fabs(1.0 - f_0 / f_small) <= 110.0 * EPS)
+
+            if idx != ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE:
+                # The simple sampler requires that Low <= 0 <= Upp
+                s_0, f_0, was_successful = solve_trsp(H, G, too_large, Upp)
+                self.assertTrue(was_successful)
+                self.assertTrue(isinstance(s_0, np.ndarray))
+                self.assertEqual(s_0.ndim, 1)
+                self.assertTrue(isinstance(f_0, numbers.Real))
+                self.assertTrue(np.fabs(1.0 - s_0 / s_large) <= 110.0 * EPS)
+                self.assertTrue(np.fabs(1.0 - f_0 / f_large) <= 1500.0 * EPS)

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -33,7 +33,8 @@ class TestCreateTrspSolver(unittest.TestCase):
     def test1D(self):
         EPS = np.finfo(float).eps
 
-        # Specify problem
+        # ----- SPECIFY PROBLEMS
+        # Unconstrained solution inside bounds
         N = 1
         G = np.array([-1.1])
         H = np.atleast_2d([2.2])
@@ -41,17 +42,19 @@ class TestCreateTrspSolver(unittest.TestCase):
         Upp = np.array([0.9])
         self.assertTrue(H[0, 0] > 0.0)
 
+        # Bounds that put unconstrained solution outside bounds
+        too_small = np.array([0.25])
+        too_large = np.array([0.8])
+
         # Known solutions
         s_expected = 0.5
-        f_expected = -0.275
+        f_expected = -11.0 / 40.0
 
-        too_small = np.array([0.25])
         s_small = too_small[0]
-        f_small = -0.20625
+        f_small = -33.0 / 160.0
 
-        too_large = np.array([0.8])
         s_large = too_large[0]
-        f_large = -0.176
+        f_large = -22.0 / 125.0
 
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
@@ -96,8 +99,6 @@ class TestCreateTrspSolver(unittest.TestCase):
                 self.assertTrue(np.fabs(1.0 - f_0 / f_large) <= 1500.0 * EPS)
 
     def test2D(self):
-        EPS = np.finfo(float).eps
-
         # Specify problem
         N = 2
         G = np.array([1.2, -2.3])
@@ -108,8 +109,8 @@ class TestCreateTrspSolver(unittest.TestCase):
         Upp = np.array([5.0, 4.0])
 
         # Known solution
-        s_expected = np.array([-0.75213675, 0.31054131])
-        f_expected = -0.8084045584045583
+        s_expected = np.array([-88.0 / 117.0, 109.0 / 351.0])
+        f_expected = -1135.0 / 1404.0
 
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
@@ -129,9 +130,11 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
             max_rel_err = np.max(np.fabs(1.0 - s_0 / s_expected))
-            self.assertTrue(max_rel_err <= 5.0e-9)
+            # print(max_rel_err)
+            self.assertTrue(max_rel_err <= 2.5e-13)
             rel_err = np.fabs(1.0 - f_0 / f_expected)
-            self.assertTrue(rel_err <= 75.0 * EPS)
+            # print(rel_err)
+            self.assertTrue(rel_err <= 2.5e-14)
 
     def test5D(self):
         # Setting maxit=600,000 in bqmin yielded a solution that was of similar
@@ -150,8 +153,8 @@ class TestCreateTrspSolver(unittest.TestCase):
         Upp = np.array([10.0, 100.0, 3.0, 0.5, 7.0])
 
         # Known solution
-        s_expected = [-128.82782698, 90.82291477, 2.8264531, -1.37446078, 5.60555695]
-        f_expected = -170.94945062515922
+        s_expected = [-18486334673.0 / 143496441.0, 1184796821.0 / 13045131.0, 368714509.0 / 130451310.0, -16300019.0 / 11859210.0, 2014469.0 / 359370.0]
+        f_expected = -4906127551123.0 / 28699288200.0
 
         for idx in self.__solvers.difference(TO_SKIP):
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
@@ -164,6 +167,8 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
             max_rel_err = np.max(np.fabs(1.0 - s_0 / s_expected))
-            self.assertTrue(max_rel_err <= 2.5e-9)
+            # print(max_rel_err)
+            self.assertTrue(max_rel_err <= 7.5e-11)
             rel_err = np.fabs(1.0 - f_0 / f_expected)
+            # print(rel_err)
             self.assertTrue(rel_err <= 7.5e-11)

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -64,8 +64,8 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertTrue(callable(solve_trsp))
 
             # Unconstrained solution in bounds
-            s_0, f_0, was_successful = solve_trsp(H, G, Low, Upp)
-            self.assertTrue(was_successful)
+            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
             self.assertEqual(len(s_0), 1)
@@ -74,8 +74,8 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertTrue(np.fabs(1.0 - f_0 / f_expected) <= 110.0 * EPS)
 
             # Unconstrained solution outside bounds
-            s_0, f_0, was_successful = solve_trsp(H, G, Low, too_small)
-            self.assertTrue(was_successful)
+            s_0, f_0, found_solution = solve_trsp(H, G, Low, too_small)
+            self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
             self.assertEqual(len(s_0), 1)
@@ -85,8 +85,8 @@ class TestCreateTrspSolver(unittest.TestCase):
 
             if idx != ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE:
                 # The simple sampler requires that Low <= 0 <= Upp
-                s_0, f_0, was_successful = solve_trsp(H, G, too_large, Upp)
-                self.assertTrue(was_successful)
+                s_0, f_0, found_solution = solve_trsp(H, G, too_large, Upp)
+                self.assertTrue(found_solution)
                 self.assertTrue(isinstance(s_0, np.ndarray))
                 self.assertEqual(s_0.ndim, 1)
                 self.assertTrue(isinstance(f_0, numbers.Real))

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -14,21 +14,25 @@ import ibcdfo
 class TestCreateTrspSolver(unittest.TestCase):
     def setUp(self):
         self.__solvers = {ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE, ibcdfo.pounders.TRSP_SOLVER_MINQ5}
-        self.__emit_warnings = {(ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE, ("testing", "debugging"))}
+        self.__emit_warnings = {ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE: ibcdfo.pounders.constants.WARNING_SIMPLE_TRSP}
+
+        warnings.simplefilter("default")
 
     def testErrors(self):
-        for bad in [0, ibcdfo.pounders.TRSP_SOLVER_MINQ8]:
+        for bad in [np.min(list(self.__solvers)) - 1, np.max(list(self.__solvers)) + 1]:
             with self.assertRaises(ValueError):
                 ibcdfo.pounders.create_trsp_solver(bad)
 
     def testWarnings(self):
-        for idx, words in self.__emit_warnings:
+        for idx in self.__solvers:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 ibcdfo.pounders.create_trsp_solver(idx)
-                self.assertEqual(len(w), 1)
-                for each in words:
-                    self.assertTrue(each in str(w[0].message))
+                if idx in self.__emit_warnings:
+                    self.assertEqual(len(w), 1)
+                    self.assertEqual(str(w[0].message), self.__emit_warnings[idx])
+                else:
+                    self.assertEqual(len(w), 0)
 
     def test1D(self):
         EPS = np.finfo(float).eps
@@ -36,7 +40,7 @@ class TestCreateTrspSolver(unittest.TestCase):
         # ----- SPECIFY PROBLEMS
         # Unconstrained solution inside bounds
         N = 1
-        G = np.array([-1.1])
+        g = np.array([-1.1])
         H = np.atleast_2d([2.2])
         Low = np.array([-1.9])
         Upp = np.array([0.9])
@@ -59,16 +63,16 @@ class TestCreateTrspSolver(unittest.TestCase):
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
             warnings.simplefilter("default")
-            for warn_idx, _ in self.__emit_warnings:
+            for warn_idx, msg in self.__emit_warnings.items():
                 if warn_idx == idx:
-                    warnings.simplefilter("ignore")
+                    warnings.filterwarnings("ignore", message=msg)
                     break
 
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
 
             # Unconstrained solution in bounds
-            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            s_0, f_0, found_solution = solve_trsp(H, g, Low, Upp)
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
@@ -78,30 +82,30 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertTrue(np.fabs(1.0 - f_0 / f_expected) <= 110.0 * EPS)
 
             # Unconstrained solution outside bounds
-            s_0, f_0, found_solution = solve_trsp(H, G, Low, too_small)
+            s_0, f_0, found_solution = solve_trsp(H, g, Low, too_small)
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
             self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
-            self.assertTrue(np.fabs(1.0 - s_0[0] / s_small) <= 110.0 * EPS)
+            self.assertEqual(s_0[0], s_small)
             self.assertTrue(np.fabs(1.0 - f_0 / f_small) <= 110.0 * EPS)
 
             if idx != ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE:
                 # The simple sampler requires that Low <= 0 <= Upp
-                s_0, f_0, found_solution = solve_trsp(H, G, too_large, Upp)
+                s_0, f_0, found_solution = solve_trsp(H, g, too_large, Upp)
                 self.assertTrue(found_solution)
                 self.assertTrue(isinstance(s_0, np.ndarray))
                 self.assertEqual(s_0.ndim, 1)
                 self.assertEqual(len(s_0), N)
                 self.assertTrue(isinstance(f_0, numbers.Real))
-                self.assertTrue(np.fabs(1.0 - s_0 / s_large) <= 110.0 * EPS)
+                self.assertEqual(s_0[0], s_large)
                 self.assertTrue(np.fabs(1.0 - f_0 / f_large) <= 1500.0 * EPS)
 
     def test2D(self):
         # Specify problem
         N = 2
-        G = np.array([1.2, -2.3])
+        g = np.array([1.2, -2.3])
         H = np.array([[1.1, -1.2], [-1.2, 4.5]])
         self.assertTrue(np.array_equal(H.T, H, equal_nan=False))
         self.assertTrue(all(np.linalg.eigvalsh(H) > 0.5))
@@ -115,15 +119,15 @@ class TestCreateTrspSolver(unittest.TestCase):
         for idx in self.__solvers:
             # Expected emission of warnings tested in testWarnings.  Ignore only those.
             warnings.simplefilter("default")
-            for warn_idx, _ in self.__emit_warnings:
+            for warn_idx, msg in self.__emit_warnings.items():
                 if warn_idx == idx:
-                    warnings.simplefilter("ignore")
+                    warnings.filterwarnings("ignore", message=msg)
                     break
 
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
 
-            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            s_0, f_0, found_solution = solve_trsp(H, g, Low, Upp)
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
@@ -140,12 +144,12 @@ class TestCreateTrspSolver(unittest.TestCase):
         # Setting maxit=600,000 in bqmin yielded a solution that was of similar
         # quality to MINQ5's solution.  Since, that's far more that the real
         # budget, we skip it.  We consider a passing 2D test as sufficient
-        # evidence of correct functionality for this unofficial solver.
+        # evidence of correct functionality for that unofficial solver.
         TO_SKIP = {ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE}
 
         # Specify problem
         N = 5
-        G = np.array([1.2, -2.3, 0.7, -0.4, 3.4])
+        g = np.array([1.2, -2.3, 0.7, -0.4, 3.4])
         H = np.array([[30.25, 38.5, 115.5, -19.25, 8.25], [38.5, 50.0, 131.0, -14.5, 5.5], [115.5, 131.0, 818.0, -211.5, 67.5], [-19.25, -14.5, -211.5, 388.5, -5.5], [8.25, 5.5, 67.5, -5.5, 64.5]])
         self.assertTrue(np.array_equal(H.T, H, equal_nan=False))
         self.assertTrue(all(np.linalg.eigvalsh(H) > 0.01))
@@ -160,7 +164,7 @@ class TestCreateTrspSolver(unittest.TestCase):
             solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
             self.assertTrue(callable(solve_trsp))
 
-            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            s_0, f_0, found_solution = solve_trsp(H, g, Low, Upp)
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -34,11 +34,12 @@ class TestCreateTrspSolver(unittest.TestCase):
         EPS = np.finfo(float).eps
 
         # Specify problem
+        N = 1
         G = np.array([-1.1])
         H = np.atleast_2d([2.2])
         Low = np.array([-1.9])
         Upp = np.array([0.9])
-        self.assertTrue(H[0] > 0.0)
+        self.assertTrue(H[0, 0] > 0.0)
 
         # Known solutions
         s_expected = 0.5
@@ -68,7 +69,7 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
-            self.assertEqual(len(s_0), 1)
+            self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
             self.assertTrue(np.fabs(1.0 - s_0[0] / s_expected) <= 110.0 * EPS)
             self.assertTrue(np.fabs(1.0 - f_0 / f_expected) <= 110.0 * EPS)
@@ -78,7 +79,7 @@ class TestCreateTrspSolver(unittest.TestCase):
             self.assertTrue(found_solution)
             self.assertTrue(isinstance(s_0, np.ndarray))
             self.assertEqual(s_0.ndim, 1)
-            self.assertEqual(len(s_0), 1)
+            self.assertEqual(len(s_0), N)
             self.assertTrue(isinstance(f_0, numbers.Real))
             self.assertTrue(np.fabs(1.0 - s_0[0] / s_small) <= 110.0 * EPS)
             self.assertTrue(np.fabs(1.0 - f_0 / f_small) <= 110.0 * EPS)
@@ -89,6 +90,80 @@ class TestCreateTrspSolver(unittest.TestCase):
                 self.assertTrue(found_solution)
                 self.assertTrue(isinstance(s_0, np.ndarray))
                 self.assertEqual(s_0.ndim, 1)
+                self.assertEqual(len(s_0), N)
                 self.assertTrue(isinstance(f_0, numbers.Real))
                 self.assertTrue(np.fabs(1.0 - s_0 / s_large) <= 110.0 * EPS)
                 self.assertTrue(np.fabs(1.0 - f_0 / f_large) <= 1500.0 * EPS)
+
+    def test2D(self):
+        EPS = np.finfo(float).eps
+
+        # Specify problem
+        N = 2
+        G = np.array([1.2, -2.3])
+        H = np.array([[1.1, -1.2], [-1.2, 4.5]])
+        self.assertTrue(np.array_equal(H.T, H, equal_nan=False))
+        self.assertTrue(all(np.linalg.eigvalsh(H) > 0.5))
+        Low = np.array([-7.0, -4.0])
+        Upp = np.array([5.0, 4.0])
+
+        # Known solution
+        s_expected = np.array([-0.75213675, 0.31054131])
+        f_expected = -0.8084045584045583
+
+        for idx in self.__solvers:
+            # Expected emission of warnings tested in testWarnings.  Ignore only those.
+            warnings.simplefilter("default")
+            for warn_idx, _ in self.__emit_warnings:
+                if warn_idx == idx:
+                    warnings.simplefilter("ignore")
+                    break
+
+            solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
+            self.assertTrue(callable(solve_trsp))
+
+            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            self.assertTrue(found_solution)
+            self.assertTrue(isinstance(s_0, np.ndarray))
+            self.assertEqual(s_0.ndim, 1)
+            self.assertEqual(len(s_0), N)
+            self.assertTrue(isinstance(f_0, numbers.Real))
+            max_rel_err = np.max(np.fabs(1.0 - s_0 / s_expected))
+            self.assertTrue(max_rel_err <= 5.0e-9)
+            rel_err = np.fabs(1.0 - f_0 / f_expected)
+            self.assertTrue(rel_err <= 75.0 * EPS)
+
+    def test5D(self):
+        # Setting maxit=600,000 in bqmin yielded a solution that was of similar
+        # quality to MINQ5's solution.  Since, that's far more that the real
+        # budget, we skip it.  We consider a passing 2D test as sufficient
+        # evidence of correct functionality for this unofficial solver.
+        TO_SKIP = {ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE}
+
+        # Specify problem
+        N = 5
+        G = np.array([1.2, -2.3, 0.7, -0.4, 3.4])
+        H = np.array([[30.25, 38.5, 115.5, -19.25, 8.25], [38.5, 50.0, 131.0, -14.5, 5.5], [115.5, 131.0, 818.0, -211.5, 67.5], [-19.25, -14.5, -211.5, 388.5, -5.5], [8.25, 5.5, 67.5, -5.5, 64.5]])
+        self.assertTrue(np.array_equal(H.T, H, equal_nan=False))
+        self.assertTrue(all(np.linalg.eigvalsh(H) > 0.01))
+        Low = np.array([-150.0, -10.0, -1.0, -2.0, -1.0])
+        Upp = np.array([10.0, 100.0, 3.0, 0.5, 7.0])
+
+        # Known solution
+        s_expected = [-128.82782698, 90.82291477, 2.8264531, -1.37446078, 5.60555695]
+        f_expected = -170.94945062515922
+
+        for idx in self.__solvers.difference(TO_SKIP):
+            solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
+            self.assertTrue(callable(solve_trsp))
+
+            s_0, f_0, found_solution = solve_trsp(H, G, Low, Upp)
+            self.assertTrue(found_solution)
+            self.assertTrue(isinstance(s_0, np.ndarray))
+            self.assertEqual(s_0.ndim, 1)
+            self.assertEqual(len(s_0), N)
+            self.assertTrue(isinstance(f_0, numbers.Real))
+            max_rel_err = np.max(np.fabs(1.0 - s_0 / s_expected))
+            self.assertTrue(max_rel_err <= 2.5e-9)
+            rel_err = np.fabs(1.0 - f_0 / f_expected)
+            self.assertTrue(rel_err <= 7.5e-11)

--- a/pounders/py/tests/TestCreateTrspSolver.py
+++ b/pounders/py/tests/TestCreateTrspSolver.py
@@ -1,0 +1,40 @@
+"""
+Unit test of create_trsp_solver()
+"""
+
+import warnings
+import unittest
+
+import ibcdfo
+
+
+class TestCreateTrspSolver(unittest.TestCase):
+    def setUp(self):
+        self.__solvers = {ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE, ibcdfo.pounders.TRSP_SOLVER_MINQ5}
+        self.__emit_warnings = {(ibcdfo.pounders.constants.TRSP_SOLVER_SIMPLE, ("testing", "debugging"))}
+
+    def testErrors(self):
+        for bad in [0, ibcdfo.pounders.TRSP_SOLVER_MINQ8]:
+            with self.assertRaises(ValueError):
+                ibcdfo.pounders.create_trsp_solver(bad)
+
+    def testWarnings(self):
+        for idx, words in self.__emit_warnings:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                ibcdfo.pounders.create_trsp_solver(idx)
+                self.assertEqual(len(w), 1)
+                for each in words:
+                    self.assertTrue(each in str(w[0].message))
+
+    def testSuccessful(self):
+        for idx in self.__solvers:
+            # Expected emission of warnings tested in testWarnings.  Ignore only those.
+            warnings.simplefilter("default")
+            for warn_idx, _ in self.__emit_warnings:
+                if warn_idx == idx:
+                    warnings.simplefilter("ignore")
+                    break
+
+            solve_trsp = ibcdfo.pounders.create_trsp_solver(idx)
+            self.assertTrue(callable(solve_trsp))


### PR DESCRIPTION
This is an intermediate step performed for both Python and MATLAB.  We should expect bitwise identical POUNDERS results compared to benchmarks.

PR Self-review

- [x] Review all changes
- [x] Confirm TRSP indices defined identically in MATLAB and Python and all spsolver docs are consistent
- [x] Confirm that passing MINQ8 in Python raises an exception with a useful error message
   * Repeated this in MATLAB but with `spsolver` set to 4
   * THIS IS NOW DONE AUTOMATICALLY IN NEW UNIT TESTS
- [x] Confirm test suite fails in both Python and MATLAB with useful message if MINQ not in PATH or local clone set to wrong commit
- [x] Confirm warning logged in both Python and MATLAB if user requests the simple solver and that MINQ can be, but does not need to be, provided.
- [x] Confirm that test script shows bitwise identical results compared to both MATLAB and Python benchmarks
- [x] Review updated POUNDERS docs as rendered by RTD for this PR 
- [x] Confirm that POUNDERS/Py and POUNDERS/concurrent-py have been altered in same way
- [x] Confirm that POUNDERS/Py and POUNDERS/m have been altered in same way
- [x] Confirm that create_trsp_solver/Py and create_trsp_solver/m sufficiently similar
- [x] Coverage of new files and changes in code coverage acceptable
- [x] Confirm all actions passing